### PR TITLE
Add Document content to ollama prompt

### DIFF
--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -9,11 +9,11 @@ class OllamaService {
         timeout: 300000 // 5 Minuten Timeout
       });
     }
-  
+
     async analyzeDocument(content, existingTags) {
       try {
         const prompt = this._buildPrompt(content, existingTags);
-        
+
         const response = await this.client.post(`${this.apiUrl}/api/generate`, {
           model: this.model,
           prompt: prompt,
@@ -24,13 +24,13 @@ class OllamaService {
             repeat_penalty: 1.1  // Verhindert Wiederholungen
           }
         });
-  
+
         // Prüfe explizit auf Response-Fehler
         if (!response.data || !response.data.response) {
           console.error('Unexpected Ollama response format:', response);
           throw new Error('Invalid response from Ollama API');
         }
-  
+
         return this._parseResponse(response.data.response);
       } catch (error) {
         if (error.code === 'ECONNABORTED') {
@@ -43,9 +43,9 @@ class OllamaService {
     }
 
   _buildPrompt(content, existingTags) {
-    return process.env.SYSTEM_PROMPT;
+    return process.env.SYSTEM_PROMPT + '\n\n' + JSON.stringify(content);
   }
-  
+
   _parseResponse(response) {
     try {
       // Find JSON in response using regex

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -9,11 +9,11 @@ class OllamaService {
         timeout: 300000 // 5 Minuten Timeout
       });
     }
-
+  
     async analyzeDocument(content, existingTags) {
       try {
         const prompt = this._buildPrompt(content, existingTags);
-
+        
         const response = await this.client.post(`${this.apiUrl}/api/generate`, {
           model: this.model,
           prompt: prompt,
@@ -24,13 +24,13 @@ class OllamaService {
             repeat_penalty: 1.1  // Verhindert Wiederholungen
           }
         });
-
+  
         // Prüfe explizit auf Response-Fehler
         if (!response.data || !response.data.response) {
           console.error('Unexpected Ollama response format:', response);
           throw new Error('Invalid response from Ollama API');
         }
-
+  
         return this._parseResponse(response.data.response);
       } catch (error) {
         if (error.code === 'ECONNABORTED') {
@@ -45,7 +45,7 @@ class OllamaService {
   _buildPrompt(content, existingTags) {
     return process.env.SYSTEM_PROMPT + '\n\n' + JSON.stringify(content);
   }
-
+  
   _parseResponse(response) {
     try {
       // Find JSON in response using regex


### PR DESCRIPTION
I've found that ollama came up with nonsensical correspondent names (akin to ACME Corp, ABC Industries etc).
Upon inspection it seems like the document information is not appended to the prompt at all so in retrospective the behaviour does make sense. 

Fun fact, no errors were seen in the logs when using mistral as a model. After switching to llama3.2, the LLM's reply actually mentions it's not able to build the requested output since the input is missing. 