### PR TITLE
Consistently refer to `dataDir`

### DIFF
--- a/models/document.js
+++ b/models/document.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const { get } = require('http');
 
 // Ensure data directory exists
-const dataDir = path.join(__dirname, '..', 'data');
+const dataDir = path.join(process.cwd(), 'data');
 if (!fs.existsSync(dataDir)) {
   fs.mkdirSync(dataDir, { recursive: true });
 }


### PR DESCRIPTION
In server.js, it is established that the `dataDir` is relative to the working directory. This change makes that consistent, as document.js was computing it relative to the source file location.