### PR TITLE
Pick the first correspondent if search returns multiple

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -735,8 +735,15 @@ class PaperlessService {
         console.log("Response Correspondent Search: ", existingCorrespondent);
     
         if (existingCorrespondent) {
-            console.log(`Found existing correspondent "${name}" with ID ${existingCorrespondent.id}`);
-            return existingCorrespondent;
+            // If only one result is found, return it
+            if (!Array.isArray(existingCorrespondent)) {
+              console.log(`Found existing correspondent "${name}" with ID ${existingCorrespondent.id}`);
+              return existingCorrespondent;
+            }
+            // If multiple results are found, return the first one
+            const firstResult = existingCorrespondent[0];
+            console.log(`Found multiple correspondents for "${name}". Returning first one with ID ${firstResult.id}`);
+            return firstResult;
         }
     
         // Erstelle neuen Korrespondenten


### PR DESCRIPTION
Currently, no correspondent is picked (`undefined`, to be precise) if the API correspondent search returns multiple results. This change simply picks the first result.

An alternative fix would be to check if the AI generated correspondent exists as a 1:1 match, and if not, force create it instead of picking from the existing list. For my documents there are generally too many correspondents being created and not too few, so I opted for the option in this PR to avoid even more.