### PR TITLE
Fix issue with the open AI service 

### DIFF
--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -85,12 +85,12 @@ class OpenAIService {
         
         const thumbnailData = await paperlessService.getThumbnailImage(id);
         
-        if (!thumbnailData) {
+        if (thumbnailData) {
+          await fs.mkdir(path.dirname(cachePath), { recursive: true });
+          await fs.writeFile(cachePath, thumbnailData);
+        } else {
           console.warn('Thumbnail nicht gefunden');
         }
-  
-        await fs.mkdir(path.dirname(cachePath), { recursive: true });
-        await fs.writeFile(cachePath, thumbnailData);
       }
       
       // Format existing tags


### PR DESCRIPTION
the open AI service analyze document function is called from the manual service without a document ID. this breaks the request and snap 'completes' in the UI when really it errored in the backend attempting to get the thumbnail from paperless.

![image](https://github.com/user-attachments/assets/fa84a1d5-bea9-4a5b-b2a2-1c74825e16a5)

![image](https://github.com/user-attachments/assets/437c1ef4-9239-40fc-8978-2b12828890ed)


