### PR TITLE
Fix chat in firefox. submit form is deprecated

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -191,9 +191,14 @@ document.getElementById('documentSelect').addEventListener('change', function() 
     }
 });
 
-document.getElementById('messageForm').addEventListener('submit', async function(e) {
-    e.preventDefault();
-    
+document.getElementById('messageInput').addEventListener('keydown', async (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        await submitForm();
+    }
+})
+
+async function submitForm(){
     const messageInput = document.getElementById('messageInput');
     const message = messageInput.value.trim();
     
@@ -214,7 +219,7 @@ document.getElementById('messageForm').addEventListener('submit', async function
         if (response) {
             addMessage(response, false);
         }
-    } catch (error) {
+    } catch {
         showError('Failed to send message');
     }
-});
+}

--- a/views/chat.ejs
+++ b/views/chat.ejs
@@ -39,7 +39,7 @@
             </div>
 
             <!-- Message Input -->
-            <form id="messageForm" class="message-form hidden">
+            <div id="messageForm" class="message-form hidden">
                 <input type="hidden" id="documentId" name="documentId" value="">
                 <textarea 
                     id="messageInput"
@@ -51,7 +51,7 @@
                 <button type="submit" class="send-button">
                     Send
                 </button>
-            </form>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
submit listener on form object is deprecated in newer firefox. Instead, attach the listener to the return key on the input.