### PR TITLE
Hide sensitive data in configuration and setup query logs

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -21,7 +21,7 @@ const limitFunctions = {
 
 console.log('Loaded environment variables:', {
   PAPERLESS_API_URL: process.env.PAPERLESS_API_URL,
-  PAPERLESS_API_TOKEN: process.env.PAPERLESS_API_TOKEN,
+  PAPERLESS_API_TOKEN: '******',
   LIMIT_FUNCTIONS: limitFunctions
 });
 

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1238,7 +1238,16 @@ router.post('/setup', express.json(), async (req, res) => {
       disableAutomaticProcessing
     } = req.body;
 
-    console.log('Setup request received:', req.body);
+    // Log setup request with sensitive data redacted
+    const sensitiveKeys = ['paperlessToken', 'openaiKey', 'customApiKey', 'password', 'confirmPassword'];
+    const redactedBody = Object.fromEntries(
+      Object.entries(req.body).map(([key, value]) => [
+      key,
+      sensitiveKeys.includes(key) ? '******' : value
+      ])
+    );
+    console.log('Setup request received:', redactedBody);
+
 
     // Initialize paperlessService with the new credentials
     const paperlessApiUrl = paperlessUrl + '/api';


### PR DESCRIPTION
Relative to #340, this pull request includes changes to improve the security of logging by removing sensitive information in the logs. 

The changes are:

* [`config/config.js`](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL24-R24): Redacted the `PAPERLESS_API_TOKEN` in the environment variables log to prevent sensitive information from being exposed.
* [`routes/setup.js`](diffhunk://#diff-43d00e4439fedf194970d1d087264e9f1ab12b33cc777234eb8be51df4c95c4aL1241-R1250): Added logic to redact sensitive keys from the setup request body before logging it, ensuring that sensitive information such as tokens and passwords are not exposed in the logs.