### PR TITLE
Add support for Azure OpenAI

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -26,7 +26,7 @@ console.log('Loaded environment variables:', {
 });
 
 module.exports = {
-  PAPERLESS_AI_VERSION: '2.7.0',
+  PAPERLESS_AI_VERSION: '2.7.1',
   CONFIGURED: false,
   disableAutomaticProcessing: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
   predefinedMode: process.env.PROCESS_PREDEFINED_DOCUMENTS,

--- a/config/config.js
+++ b/config/config.js
@@ -48,6 +48,12 @@ module.exports = {
     apiKey: process.env.CUSTOM_API_KEY || '',
     model: process.env.CUSTOM_MODEL || ''
   },
+  azure: {
+    apiKey: process.env.AZURE_API_KEY || '',
+    endpoint: process.env.AZURE_ENDPOINT || '',
+    deploymentName: process.env.AZURE_DEPLOYMENT_NAME || '',
+    apiVersion: process.env.AZURE_API_VERSION || '2023-05-15'
+  },
   customFields: process.env.CUSTOM_FIELDS || '',
   aiProvider: process.env.AI_PROVIDER || 'openai',
   scanInterval: process.env.SCAN_INTERVAL || '*/30 * * * *',

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -82,7 +82,8 @@ class FormManager {
         const openaiSettings = document.getElementById('openaiSettings');
         const ollamaSettings = document.getElementById('ollamaSettings');
         const customSettings = document.getElementById('customSettings');
-        
+        const azureSettings = document.getElementById('azureSettings');
+
         // Get all provider-specific fields
         const openaiKey = document.getElementById('openaiKey');
         const ollamaUrl = document.getElementById('ollamaUrl');
@@ -90,11 +91,16 @@ class FormManager {
         const customBaseUrl = document.getElementById('customBaseUrl');
         const customApiKey = document.getElementById('customApiKey');
         const customModel = document.getElementById('customModel');
+        const azureApiKey = document.getElementById('azureApiKey');
+        const azureEndpoint = document.getElementById('azureEndpoint');
+        const azureDeploymentName = document.getElementById('azureDeploymentName');
+        const azureApiVersion = document.getElementById('azureApiVersion');
         
         // Hide all settings sections first
         openaiSettings.classList.add('hidden');
         ollamaSettings.classList.add('hidden');
         customSettings.classList.add('hidden');
+        azureSettings.classList.add('hidden');
         
         // Reset all required fields
         openaiKey.required = false;
@@ -103,6 +109,10 @@ class FormManager {
         customBaseUrl.required = false;
         customApiKey.required = false;
         customModel.required = false;
+        azureApiKey.required = false;
+        azureEndpoint.required = false;
+        azureDeploymentName.required = false;
+        azureApiVersion.required = false;
         
         // Show and set required fields based on selected provider
         switch (provider) {
@@ -120,6 +130,13 @@ class FormManager {
                 customBaseUrl.required = true;
                 customApiKey.required = true;
                 customModel.required = true;
+                break;
+            case 'azure':
+                azureSettings.classList.remove('hidden');
+                azureApiKey.required = true;
+                azureEndpoint.required = true;
+                azureDeploymentName.required = true;
+                azureApiVersion.required = true;
                 break;
         }
     }

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -83,6 +83,7 @@ class FormManager {
         const openaiSettings = document.getElementById('openaiSettings');
         const ollamaSettings = document.getElementById('ollamaSettings');
         const customSettings = document.getElementById('customSettings');
+        const azureSettings = document.getElementById('azureSettings');
         
         // Get all required fields
         const openaiKey = document.getElementById('openaiKey');
@@ -91,11 +92,16 @@ class FormManager {
         const customBaseUrl = document.getElementById('customBaseUrl');
         const customApiKey = document.getElementById('customApiKey');
         const customModel = document.getElementById('customModel');
+        const azureApiKey = document.getElementById('azureApiKey');
+        const azureEndpoint = document.getElementById('azureEndpoint');
+        const azureModel = document.getElementById('azureApiVersion');
+        const azureDeployment = document.getElementById('azureDeploymentName');
         
         // Hide all settings first
         openaiSettings.style.display = 'none';
         ollamaSettings.style.display = 'none';
         customSettings.style.display = 'none';
+        azureSettings.style.display = 'none';
         
         // Reset all required attributes
         openaiKey.required = false;
@@ -104,6 +110,10 @@ class FormManager {
         customBaseUrl.required = false;
         customApiKey.required = false;
         customModel.required = false;
+        azureApiKey.required = false;
+        azureEndpoint.required = false;
+        azureModel.required = false;
+        azureDeployment.required = false;
         
         // Show and set required fields based on selected provider
         switch (provider) {
@@ -121,6 +131,13 @@ class FormManager {
                 customBaseUrl.required = true;
                 customApiKey.required = true;
                 customModel.required = true;
+                break;
+            case 'azure':
+                azureSettings.style.display = 'block';
+                azureApiKey.required = true;
+                azureEndpoint.required = true;
+                azureModel.required = true;
+                azureDeployment.required = true;
                 break;
         }
     }

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1127,6 +1127,15 @@ router.post('/manual/playground', express.json(), async (req, res) => {
         analyzeDocument.metrics.totalTokens
       )
       return res.json(analyzeDocument);
+    } else if (process.env.AI_PROVIDER === 'azure') {
+      const analyzeDocument = await azureService.analyzePlayground(content, prompt);
+      await documentModel.addOpenAIMetrics(
+        documentId, 
+        analyzeDocument.metrics.promptTokens,
+        analyzeDocument.metrics.completionTokens,
+        analyzeDocument.metrics.totalTokens
+      )
+      return res.json(analyzeDocument);
     } else {
       return res.status(500).json({ error: 'AI provider not configured' });
     }

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -684,6 +684,10 @@ router.get('/setup', async (req, res) => {
       PROCESS_ONLY_NEW_DOCUMENTS: process.env.PROCESS_ONLY_NEW_DOCUMENTS || 'yes',
       USE_EXISTING_DATA: process.env.USE_EXISTING_DATA || 'no',
       DISABLE_AUTOMATIC_PROCESSING: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
+      AZURE_ENDPOINT: process.env.AZURE_ENDPOINT|| '',
+      AZURE_API_KEY: process.env.AZURE_API_KEY || '',
+      AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
+      AZURE_API_VERSION: process.env.AZURE_API_VERSION || ''
     };
 
     // Check both configuration and users
@@ -992,7 +996,11 @@ router.get('/settings', async (req, res) => {
     USE_EXISTING_DATA: process.env.USE_EXISTING_DATA || 'no',
     CUSTOM_API_KEY: process.env.CUSTOM_API_KEY || '',
     CUSTOM_BASE_URL: process.env.CUSTOM_BASE_URL || '',
-    CUSTOM_MODEL: process.env.CUSTOM_MODEL || ''
+    CUSTOM_MODEL: process.env.CUSTOM_MODEL || '',
+    AZURE_ENDPOINT: process.env.AZURE_ENDPOINT|| '',
+    AZURE_API_KEY: process.env.AZURE_API_KEY || '',
+    AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
+    AZURE_API_VERSION: process.env.AZURE_API_VERSION || ''
   };
   
   if (isConfigured) {
@@ -1448,7 +1456,11 @@ router.post('/settings', express.json(), async (req, res) => {
       activateTitle,
       activateCustomFields,
       customFields,  // Added parameter
-      disableAutomaticProcessing
+      disableAutomaticProcessing,
+      azureEndpoint,
+      azureApiKey,
+      azureDeploymentName,
+      azureApiVersion
     } = req.body;
 
     //replace equal char in system prompt
@@ -1485,7 +1497,11 @@ router.post('/settings', express.json(), async (req, res) => {
       ACTIVATE_TITLE: process.env.ACTIVATE_TITLE || 'yes',
       ACTIVATE_CUSTOM_FIELDS: process.env.ACTIVATE_CUSTOM_FIELDS || 'yes',
       CUSTOM_FIELDS: process.env.CUSTOM_FIELDS || '{"custom_fields":[]}',  // Added default
-      DISABLE_AUTOMATIC_PROCESSING: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no'
+      DISABLE_AUTOMATIC_PROCESSING: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
+      AZURE_ENDPOINT: process.env.AZURE_ENDPOINT|| '',
+      AZURE_API_KEY: process.env.AZURE_API_KEY || '',
+      AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
+      AZURE_API_VERSION: process.env.AZURE_API_VERSION || ''
     };
 
     // Process custom fields
@@ -1564,6 +1580,17 @@ router.post('/settings', express.json(), async (req, res) => {
         }
         if (ollamaUrl) updatedConfig.OLLAMA_API_URL = ollamaUrl;
         if (ollamaModel) updatedConfig.OLLAMA_MODEL = ollamaModel;
+      } else if (aiProvider === 'azure') {
+        const isAzureValid = await setupService.validateAzureConfig(azureApiKey, azureEndpoint, azureDeploymentName, azureApiVersion);
+        if (!isAzureValid) {
+          return res.status(400).json({
+            error: 'Azure connection failed. Please check URL, API Key, Deployment Name and API Version.'
+          });
+        }
+        if(azureEndpoint) updatedConfig.AZURE_ENDPOINT = azureEndpoint;
+        if(azureApiKey) updatedConfig.AZURE_API_KEY = azureApiKey;
+        if(azureDeploymentName) updatedConfig.AZURE_DEPLOYMENT_NAME = azureDeploymentName;
+        if(azureApiVersion) updatedConfig.AZURE_API_VERSION = azureApiVersion;
       }
     }
 

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1077,6 +1077,9 @@ router.post('/manual/analyze', express.json(), async (req, res) => {
     } else if (process.env.AI_PROVIDER === 'custom') {
       const analyzeDocument = await customService.analyzeDocument(content, existingTags, existingCorrespondentList, id || []);
       return res.json(analyzeDocument);
+    } else if (process.env.AI_PROVIDER === 'azure') {
+      const analyzeDocument = await azureService.analyzeDocument(content, existingTags, existingCorrespondentList, id || []);
+      return res.json(analyzeDocument);
     } else {
       return res.status(500).json({ error: 'AI provider not configured' });
     }

--- a/services/aiServiceFactory.js
+++ b/services/aiServiceFactory.js
@@ -2,6 +2,7 @@ const config = require('../config/config');
 const openaiService = require('./openaiService');
 const ollamaService = require('./ollamaService');
 const customService = require('./customService');
+const azureService = require('./azureService');
 
 class AIServiceFactory {
   static getService() {
@@ -13,6 +14,8 @@ class AIServiceFactory {
         return openaiService;
       case 'custom':
         return customService;
+      case 'azure':
+        return azureService;
     }
   }
 }

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -1,0 +1,365 @@
+const OpenAI = require('openai');
+const AzureOpenAI = require('openai').AzureOpenAI;
+const config = require('../config/config');
+const tiktoken = require('tiktoken');
+const paperlessService = require('./paperlessService');
+const fs = require('fs').promises;
+const path = require('path');
+
+class OpenAIService {
+  constructor() {
+    this.client = null;
+    this.tokenizer = null;
+  }
+
+  initialize() {
+    if (!this.client && config.aiProvider === 'ollama') {
+      this.client = new OpenAI({
+        baseURL: config.ollama.apiUrl + '/v1',
+        apiKey: 'ollama'
+      });
+    } else if (!this.client && config.aiProvider === 'custom') {
+      this.client = new OpenAI({
+        baseURL: config.custom.apiUrl,
+        apiKey: config.custom.apiKey
+      });
+    } else if (!this.client && config.aiProvider === 'openai') {
+    if (!this.client && config.openai.apiKey) {
+      this.client = new OpenAI({
+        apiKey: config.openai.apiKey
+      });
+    }
+    } else if (!this.client && config.aiProvider === 'azure') {
+      this.client = new AzureOpenAI({
+        apiKey: config.azure.apiKey,
+        endpoint: config.azure.endpoint,
+        deploymentName: config.azure.deploymentName,
+        apiVersion: config.azure.apiVersion
+      });
+    }
+  }
+
+  // Calculate tokens for a given text
+  async calculateTokens(text) {
+    if (!this.tokenizer) {
+      // Use the appropriate model encoding
+      this.tokenizer = await tiktoken.encoding_for_model(process.env.OPENAI_MODEL || "gpt-4o-mini");
+    }
+    return this.tokenizer.encode(text).length;
+  }
+
+  // Calculate tokens for a given text
+  async calculateTotalPromptTokens(systemPrompt, additionalPrompts = []) {
+    let totalTokens = 0;
+    
+    // Count tokens for system prompt
+    totalTokens += await this.calculateTokens(systemPrompt);
+    
+    // Count tokens for additional prompts
+    for (const prompt of additionalPrompts) {
+      if (prompt) { // Only count if prompt exists
+        totalTokens += await this.calculateTokens(prompt);
+      }
+    }
+    
+    // Add tokens for message formatting (approximately 4 tokens per message)
+    const messageCount = 1 + additionalPrompts.filter(p => p).length; // Count system + valid additional prompts
+    totalTokens += messageCount * 4;
+    
+    return totalTokens;
+  }
+
+  // Truncate text to fit within token limit
+  async truncateToTokenLimit(text, maxTokens) {
+    const tokens = await this.calculateTokens(text);
+    if (tokens <= maxTokens) return text;
+
+    // Simple truncation strategy - could be made more sophisticated
+    const ratio = maxTokens / tokens;
+    return text.slice(0, Math.floor(text.length * ratio));
+  }
+
+  async analyzeDocument(content, existingTags = [], existingCorrespondentList = [], id, customPrompt = null) {
+    const cachePath = path.join('./public/images', `${id}.png`);
+    try {
+      this.initialize();
+      const now = new Date();
+      const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+      
+      if (!this.client) {
+        throw new Error('OpenAI client not initialized');
+      }
+
+      // Handle thumbnail caching
+      try {
+        await fs.access(cachePath);
+        console.log('[DEBUG] Thumbnail already cached');
+      } catch (err) {
+        console.log('Thumbnail not cached, fetching from Paperless');
+        
+        const thumbnailData = await paperlessService.getThumbnailImage(id);
+        
+        if (!thumbnailData) {
+          console.warn('Thumbnail nicht gefunden');
+        }
+  
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, thumbnailData);
+      }
+      
+      // Format existing tags
+      const existingTagsList = existingTags
+        .map(tag => tag.name)
+        .join(', ');
+
+      let systemPrompt = '';
+      let promptTags = '';
+      const model = process.env.OPENAI_MODEL;
+      
+      // Parse CUSTOM_FIELDS from environment variable
+      let customFieldsObj;
+      try {
+        customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
+      } catch (error) {
+        console.error('Failed to parse CUSTOM_FIELDS:', error);
+        customFieldsObj = { custom_fields: [] };
+      }
+
+      // Generate custom fields template for the prompt
+      const customFieldsTemplate = {};
+
+      customFieldsObj.custom_fields.forEach((field, index) => {
+        customFieldsTemplate[index] = {
+          field_name: field.value,
+          value: "Fill in the value based on your analysis"
+        };
+      });
+
+      // Convert template to string for replacement and wrap in custom_fields
+      const customFieldsStr = '"custom_fields": ' + JSON.stringify(customFieldsTemplate, null, 2)
+        .split('\n')
+        .map(line => '    ' + line)  // Add proper indentation
+        .join('\n');
+
+      // Get system prompt and model
+      if(process.env.USE_EXISTING_DATA === 'yes') {
+        systemPrompt = `
+        Prexisting tags: ${existingTagsList}\n\n
+        Prexisiting correspondent: ${existingCorrespondentList}\n\n
+        ` + process.env.SYSTEM_PROMPT + '\n\n' + config.mustHavePrompt.replace('%CUSTOMFIELDS%', customFieldsStr);
+        promptTags = '';
+      } else {
+        config.mustHavePrompt = config.mustHavePrompt.replace('%CUSTOMFIELDS%', customFieldsStr);
+        systemPrompt = process.env.SYSTEM_PROMPT + '\n\n' + config.mustHavePrompt;
+        promptTags = '';
+      }
+
+      if (process.env.USE_PROMPT_TAGS === 'yes') {
+        promptTags = process.env.PROMPT_TAGS;
+        systemPrompt = `
+        Take these tags and try to match one or more to the document content.\n\n
+        ` + config.specialPromptPreDefinedTags;
+      }
+
+      if (customPrompt) {
+        console.log('[DEBUG] Replace system prompt with custom prompt via WebHook');
+        systemPrompt = customPrompt + '\n\n' + config.mustHavePrompt;
+      }
+      
+      // Rest of the function remains the same
+      const totalPromptTokens = await this.calculateTotalPromptTokens(
+        systemPrompt,
+        process.env.USE_PROMPT_TAGS === 'yes' ? [promptTags] : []
+      );
+      
+      const maxTokens = 128000;
+      const reservedTokens = totalPromptTokens + 1000;
+      const availableTokens = maxTokens - reservedTokens;
+      
+      const truncatedContent = await this.truncateToTokenLimit(content, availableTokens);
+      
+      await this.writePromptToFile(systemPrompt, truncatedContent);
+
+      const response = await this.client.chat.completions.create({
+        model: model,
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt
+          },
+          {
+            role: "user",
+            content: truncatedContent
+          }
+        ],
+        temperature: 0.3,
+      });
+      
+      if (!response?.choices?.[0]?.message?.content) {
+        throw new Error('Invalid API response structure');
+      }
+      
+      console.log(`[DEBUG] [${timestamp}] OpenAI request sent`);
+      console.log(`[DEBUG] [${timestamp}] Total tokens: ${response.usage.total_tokens}`);
+      
+      const usage = response.usage;
+      const mappedUsage = {
+        promptTokens: usage.prompt_tokens,
+        completionTokens: usage.completion_tokens,
+        totalTokens: usage.total_tokens
+      };
+
+      let jsonContent = response.choices[0].message.content;
+      jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+      let parsedResponse;
+      try {
+        parsedResponse = JSON.parse(jsonContent);
+        //write to file and append to the file (txt)
+        fs.appendFile('./logs/response.txt', jsonContent, (err) => {
+          if (err) throw err;
+        });
+      } catch (error) {
+        console.error('Failed to parse JSON response:', error);
+        throw new Error('Invalid JSON response from API');
+      }
+
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        throw new Error('Invalid response structure: missing tags array or correspondent string');
+      }
+
+      return { 
+        document: parsedResponse, 
+        metrics: mappedUsage,
+        truncated: truncatedContent.length < content.length
+      };
+    } catch (error) {
+      console.error('Failed to analyze document:', error);
+      return { 
+        document: { tags: [], correspondent: null },
+        metrics: null,
+        error: error.message 
+      };
+    }
+}
+
+  async writePromptToFile(systemPrompt, truncatedContent) {
+    const filePath = './logs/prompt.txt';
+    const maxSize = 10 * 1024 * 1024;
+  
+    try {
+      const stats = await fs.stat(filePath);
+      if (stats.size > maxSize) {
+        await fs.unlink(filePath); // Delete the file if is biger 10MB
+      }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.warn('[WARNING] Error checking file size:', error);
+      }
+    }
+  
+    try {
+      await fs.appendFile(filePath, systemPrompt + truncatedContent + '\n\n');
+    } catch (error) {
+      console.error('[ERROR] Error writing to file:', error);
+    }
+  }
+
+  async analyzePlayground(content, prompt) {
+    const musthavePrompt = `
+    Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.:  
+        {
+          "title": "xxxxx",
+          "correspondent": "xxxxxxxx",
+          "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
+          "document_date": "YYYY-MM-DD",
+          "language": "en/de/es/..."
+        }`;
+
+    try {
+      this.initialize();
+      const now = new Date();
+      const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+      
+      if (!this.client) {
+        throw new Error('OpenAI client not initialized - missing API key');
+      }
+      
+      // Calculate total prompt tokens including musthavePrompt
+      const totalPromptTokens = await this.calculateTotalPromptTokens(
+        prompt + musthavePrompt // Combined system prompt
+      );
+      
+      // Calculate available tokens
+      const maxTokens = 128000;
+      const reservedTokens = totalPromptTokens + 1000; // Reserve for response
+      const availableTokens = maxTokens - reservedTokens;
+      
+      // Truncate content if necessary
+      const truncatedContent = await this.truncateToTokenLimit(content, availableTokens);
+      
+      // Make API request
+      const response = await this.client.chat.completions.create({
+        model: process.env.OPENAI_MODEL,
+        messages: [
+          {
+            role: "system",
+            content: prompt + musthavePrompt
+          },
+          {
+            role: "user",
+            content: truncatedContent
+          }
+        ],
+        temperature: 0.3,
+      });
+      
+      // Handle response
+      if (!response?.choices?.[0]?.message?.content) {
+        throw new Error('Invalid API response structure');
+      }
+      
+      // Log token usage
+      console.log(`[DEBUG] [${timestamp}] OpenAI request sent`);
+      console.log(`[DEBUG] [${timestamp}] Total tokens: ${response.usage.total_tokens}`);
+      
+      const usage = response.usage;
+      const mappedUsage = {
+        promptTokens: usage.prompt_tokens,
+        completionTokens: usage.completion_tokens,
+        totalTokens: usage.total_tokens
+      };
+
+      let jsonContent = response.choices[0].message.content;
+      jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+      let parsedResponse;
+      try {
+        parsedResponse = JSON.parse(jsonContent);
+      } catch (error) {
+        console.error('Failed to parse JSON response:', error);
+        throw new Error('Invalid JSON response from API');
+      }
+
+      // Validate response structure
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        throw new Error('Invalid response structure: missing tags array or correspondent string');
+      }
+
+      return { 
+        document: parsedResponse, 
+        metrics: mappedUsage,
+        truncated: truncatedContent.length < content.length
+      };
+    } catch (error) {
+      console.error('Failed to analyze document:', error);
+      return { 
+        document: { tags: [], correspondent: null },
+        metrics: null,
+        error: error.message 
+      };
+    }
+  }
+}
+
+module.exports = new OpenAIService();

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -114,7 +114,7 @@ class OpenAIService {
 
       let systemPrompt = '';
       let promptTags = '';
-      const model = process.env.OPENAI_MODEL;
+      const model = process.env.AZURE_DEPLOYMENT_NAME;
       
       // Parse CUSTOM_FIELDS from environment variable
       let customFieldsObj;

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -6,7 +6,7 @@ const paperlessService = require('./paperlessService');
 const fs = require('fs').promises;
 const path = require('path');
 
-class OpenAIService {
+class AzureOpenAIService {
   constructor() {
     this.client = null;
     this.tokenizer = null;
@@ -362,4 +362,4 @@ class OpenAIService {
   }
 }
 
-module.exports = new OpenAIService();
+module.exports = new AzureOpenAIService();

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -87,7 +87,7 @@ class AzureOpenAIService {
       const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
       
       if (!this.client) {
-        throw new Error('OpenAI client not initialized');
+        throw new Error('AzureOpenAI client not initialized');
       }
 
       // Handle thumbnail caching

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -199,7 +199,7 @@ class AzureOpenAIService {
         throw new Error('Invalid API response structure');
       }
       
-      console.log(`[DEBUG] [${timestamp}] OpenAI request sent`);
+      console.log(`[DEBUG] [${timestamp}] Azure request sent`);
       console.log(`[DEBUG] [${timestamp}] Total tokens: ${response.usage.total_tokens}`);
       
       const usage = response.usage;

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -147,7 +147,6 @@ class ChatService {
       } else if (process.env.AI_PROVIDER === 'azure') {
         apiUrl = `${process.env.AZURE_ENDPOINT}/openai/deployments/${process.env.AZURE_DEPLOYMENT_NAME}/chat/completions?api-version=${process.env.AZURE_API_VERSION}`;
         headers['api-key'] = process.env.AZURE_API_KEY;
-        //headers['Content-Type'] = 'application/json';
         requestBody = {
           model: process.env.AZURE_DEPLOYMENT_NAME,
           messages: chatData.messages,

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -144,7 +144,16 @@ class ChatService {
           messages: chatData.messages,
           stream: true
         };
-      } else {
+      } else if (process.env.AI_PROVIDER === 'azure') {
+        apiUrl = `${process.env.AZURE_ENDPOINT}/openai/deployments/${process.env.AZURE_DEPLOYMENT_NAME}/chat/completions?api-version=${process.env.AZURE_API_VERSION}`;
+        headers['api-key'] = process.env.AZURE_API_KEY;
+        //headers['Content-Type'] = 'application/json';
+        requestBody = {
+          model: process.env.AZURE_DEPLOYMENT_NAME,
+          messages: chatData.messages,
+          stream: true
+        };
+      }else {
         throw new Error('AI Provider not configured');
       }
 

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -253,6 +253,7 @@
                                         <option value="openai" <%= config.AI_PROVIDER === 'openai' ? 'selected' : '' %>>OpenAI (ChatGPT)</option>
                                         <option value="ollama" <%= config.AI_PROVIDER === 'ollama' ? 'selected' : '' %>>Ollama (Local LLM)</option>
                                         <option value="custom" <%= config.AI_PROVIDER === 'custom' ? 'selected' : '' %>>Custom</option>
+                                        <option value="azure" <%= config.AI_PROVIDER === 'azure' ? 'selected' : '' %>>Azure</option>
                                     </select>
                                 </div>
 
@@ -339,6 +340,53 @@
                                             value="<%= config.CUSTOM_MODEL %>"
                                             class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                             placeholder="Enter model name">
+                                    </div>
+                                </div>
+
+                                <!-- Azure Settings -->
+                                <div id="azureSettings" class="space-y-4">
+                                    <div class="space-y-2">
+                                        <label for="azureEndpoint">Endpoint</label>
+                                        <input type="text" 
+                                               id="azureEndpoint" 
+                                               name="azureEndpoint"
+                                               value="<%= config.AZURE_ENDPOINT %>"
+                                               class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="https://api.example.com">
+                                    </div>
+                                    
+                                    <div class="space-y-2">
+                                        <label for="azureApiKey">API Key</label>
+                                        <div class="relative">
+                                            <input type="password" 
+                                                   id="azureApiKey" 
+                                                   name="azureApiKey"
+                                                   value="<%= config.AZURE_API_KEY %>"
+                                                   class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                            <button type="button" class="password-toggle" data-input="azureApiKey">
+                                                <i class="fas fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    
+                                    <div class="space-y-2">
+                                        <label for="azureDeploymentName">Deployment</label>
+                                        <input type="text" 
+                                               id="azureDeploymentName" 
+                                               name="azureDeploymentName"
+                                               value="<%= config.AZURE_DEPLOYMENT_NAME %>"
+                                               class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Enter deployment name">
+                                    </div>
+
+                                    <div class="space-y-2">
+                                        <label for="azureApiVersion">API Version</label>
+                                        <input type="text" 
+                                               id="azureApiVersion" 
+                                               name="azureApiVersion"
+                                               value="<%= config.AZURE_API_VERSION %>"
+                                               class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Enter API version">
                                     </div>
                                 </div>
                             </div>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -206,6 +206,9 @@
                                             <option value="custom" <%= config.AI_PROVIDER === 'custom' ? 'selected' : '' %>>
                                                 Custom
                                             </option>
+                                            <option value="azure" <%= config.AI_PROVIDER === 'azure' ? 'selected' : '' %>>
+                                                Azure
+                                            </option>
                                         </select>
                                     </div>
 
@@ -292,6 +295,54 @@
                                                    value="<%= config.CUSTOM_MODEL %>"
                                                    class="modern-input"
                                                    placeholder="Enter model name">
+                                        </div>
+                                    </div>
+
+                                    
+                                    <!-- Azure Settings -->
+                                    <div id="azureSettings" class="provider-settings">
+                                        <div class="form-group">
+                                            <label for="azureEndpoint">Endpoint</label>
+                                            <input type="text" 
+                                                   id="azureEndpoint" 
+                                                   name="azureEndpoint"
+                                                   value="<%= config.AZURE_ENDPOINT %>"
+                                                   class="modern-input"
+                                                   placeholder="https://api.example.com">
+                                        </div>
+                                        
+                                        <div class="form-group">
+                                            <label for="azureApiKey">API Key</label>
+                                            <div class="password-input">
+                                                <input type="password" 
+                                                       id="azureApiKey" 
+                                                       name="azureApiKey"
+                                                       value="<%= config.AZURE_API_KEY %>"
+                                                       class="modern-input">
+                                                <button type="button" class="password-toggle" data-input="azureApiKey">
+                                                    <i class="fas fa-eye"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+                                        
+                                        <div class="form-group">
+                                            <label for="azureDeploymentName">Deployment</label>
+                                            <input type="text" 
+                                                   id="azureDeploymentName" 
+                                                   name="azureDeploymentName"
+                                                   value="<%= config.AZURE_DEPLOYMENT_NAME %>"
+                                                   class="modern-input"
+                                                   placeholder="Enter deployment name">
+                                        </div>
+
+                                        <div class="form-group">
+                                            <label for="azureApiVersion">API Version</label>
+                                            <input type="text" 
+                                                   id="azureApiVersion" 
+                                                   name="azureApiVersion"
+                                                   value="<%= config.AZURE_API_VERSION %>"
+                                                   class="modern-input"
+                                                   placeholder="Enter API version">
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Although Azure OpenAI makes available standard ChatGPT (and other) models, it uses a non-standard API that cannot be supported through the "Custom" model connector. Instead, connections to Azure OpenAI require the use of the AzureOpenAI class from the OpenAI package (see [https://github.com/openai/openai-node/blob/HEAD/azure.md](https://github.com/openai/openai-node/blob/HEAD/azure.md)). 

This pull request adds a new 'Azure' AI Provider option that collects the additional inputs required for Azure support, and sets up AI model connections using the AzureOpenAI class. It also implements Azure-specific manual connection code to the chatService, mimicking the setup used for the other supported AI Providers.