### PR TITLE
Ollama: Add support for structured output and DeepSeek

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -41,7 +41,8 @@ module.exports = {
   },
   ollama: {
     apiUrl: process.env.OLLAMA_API_URL || 'http://localhost:11434',
-    model: process.env.OLLAMA_MODEL || 'llama3.2'
+    model: process.env.OLLAMA_MODEL || 'llama3.2',
+    structuredOutput: process.env.OLLAMA_STRUCTURED_OUTPUT || 'yes'
   },
   custom: {
     apiUrl: process.env.CUSTOM_BASE_URL || '',
@@ -59,25 +60,21 @@ module.exports = {
     activateTitle: limitFunctions.activateTitle,
     activateCustomFields: limitFunctions.activateCustomFields
   },
-  specialPromptPreDefinedTags: `You are a document analysis AI. You will analyze the document. 
+
+  specialPromptPreDefinedTagsWithoutJson: `You are a document analysis AI. You will analyze the document. 
   You take the main information to associate tags with the document. 
   You will also find the correspondent of the document (Sender not receiver). Also you find a meaningful and short title for the document.
   You are given a list of tags: ${process.env.PROMPT_TAGS}
   Only use the tags from the list and try to find the best fitting tags.
   You do not ask for additional information, you only use the information given in the document.
   
-  Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.:
-  {
-    "title": "xxxxx",
-    "correspondent": "xxxxxxxx",
-    "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
-    "document_date": "YYYY-MM-DD",
-    "language": "en/de/es/...",
-    %CUSTOMFIELDS%
-  }`,
-  mustHavePrompt: `Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
+  Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.`,
+  get specialPromptPreDefinedTags() { return `${this.specialPromptPreDefinedTagsWithoutJson}\n${this.jsonPrompt}` },
+  mustHavePromptWithoutJson: `Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
   IMPORTANT: The custom_fields are optional and can be left out if not needed, only try to fill out the values if you find a matching information in the document.
-  Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.
+  Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.`,
+  get mustHavePrompt() { return `${this.mustHavePromptWithoutJson}\n${this.jsonPrompt}` },
+  jsonPrompt: `
   {
     "title": "xxxxx",
     "correspondent": "xxxxxxxx",
@@ -87,4 +84,58 @@ module.exports = {
     "language": "en/de/es/...",
     %CUSTOMFIELDS%
   }`,
+  jsonFormat: {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "The title of the document."
+      },
+      "correspondent": {
+        "type": "string",
+        "description": "The name of the correspondent related to the document."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of tags associated with the document."
+      },
+      "document_type": {
+        "type": "string",
+        "description": "The type of document, e.g., 'invoice', 'contract', ..."
+      },
+      "document_date": {
+        "type": "string",
+        "format": "date",
+        "description": "The date of the document in YYYY-MM-DD format."
+      },
+      "language": {
+        "type": "string",
+        "description": "The language of the document in ISO 639-1 format."
+      }
+    },
+    "required": [
+      "title",
+      "document_type",
+      "correspondent",
+      "tags",
+      "document_date",
+      "language"
+    ]
+  },
+  jsonFormatx: {
+    "title": "string",
+    "correspondent": "string",
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "document_type": "string",
+    "document_date": "string",
+    "language": "string"
+  },
 };

--- a/config/config.js
+++ b/config/config.js
@@ -60,20 +60,19 @@ module.exports = {
     activateTitle: limitFunctions.activateTitle,
     activateCustomFields: limitFunctions.activateCustomFields
   },
-
-  specialPromptPreDefinedTagsWithoutJson: `You are a document analysis AI. You will analyze the document. 
-  You take the main information to associate tags with the document. 
-  You will also find the correspondent of the document (Sender not receiver). Also you find a meaningful and short title for the document.
-  You are given a list of tags: ${process.env.PROMPT_TAGS}
-  Only use the tags from the list and try to find the best fitting tags.
-  You do not ask for additional information, you only use the information given in the document.
-  
-  Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.`,
-  get specialPromptPreDefinedTags() { return `${this.specialPromptPreDefinedTagsWithoutJson}\n${this.jsonPrompt}` },
-  mustHavePromptWithoutJson: `Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
-  IMPORTANT: The custom_fields are optional and can be left out if not needed, only try to fill out the values if you find a matching information in the document.
-  Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.`,
+  mustHavePromptWithoutJson: `You are a document analysis AI. You will analyze the document.
+    You take the main information to associate tags with the document.
+    You will also find the correspondent of the document (Sender not receiver). Also you find a meaningful and short title for the document.
+    You do not ask for additional information, you only use the information given in the document.
+    Return the result EXCLUSIVELY as a JSON object. If not told differently, all values in the response MUST be in the language that is used in the document.
+    IMPORTANT: The custom_fields are optional and can be left out if not needed, only try to fill out the values if you find a matching information in the document.
+    Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.`,
   get mustHavePrompt() { return `${this.mustHavePromptWithoutJson}\n${this.jsonPrompt}` },
+  specialPromptPreDefinedTagsWithoutJson() { return `${this.mustHavePromptWithoutJson}
+    You are given a list of tags: ${process.env.PROMPT_TAGS}
+    Only use the tags from the list and try to find the best fitting tags.` },
+  get specialPromptPreDefinedTags() { return `${this.specialPromptPreDefinedTagsWithoutJson}\n${this.jsonPrompt}` },
+  existingDataPrompt: `You MUST only use tags and correspondents from the following list:`,
   jsonPrompt: `
   {
     "title": "xxxxx",

--- a/config/config.js
+++ b/config/config.js
@@ -61,7 +61,7 @@ module.exports = {
   },
   specialPromptPreDefinedTags: `You are a document analysis AI. You will analyze the document. 
   You take the main information to associate tags with the document. 
-  You will also find the correspondent of the document (Sender not reciever). Also you find a meaningful and short title for the document.
+  You will also find the correspondent of the document (Sender not receiver). Also you find a meaningful and short title for the document.
   You are given a list of tags: ${process.env.PROMPT_TAGS}
   Only use the tags from the list and try to find the best fitting tags.
   You do not ask for additional information, you only use the information given in the document.
@@ -72,9 +72,10 @@ module.exports = {
     "correspondent": "xxxxxxxx",
     "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
     "document_date": "YYYY-MM-DD",
-    "language": "en/de/es/..."
+    "language": "en/de/es/...",
+    %CUSTOMFIELDS%
   }`,
-  mustHavePrompt: `  Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
+  mustHavePrompt: `Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
   IMPORTANT: The custom_fields are optional and can be left out if not needed, only try to fill out the values if you find a matching information in the document.
   Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.
   {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -87,6 +87,7 @@ class FormManager {
         const openaiKey = document.getElementById('openaiKey');
         const ollamaUrl = document.getElementById('ollamaUrl');
         const ollamaModel = document.getElementById('ollamaModel');
+        const ollamaStructuredOutput = document.getElementById('ollamaStructuredOutput');
         const customBaseUrl = document.getElementById('customBaseUrl');
         const customApiKey = document.getElementById('customApiKey');
         const customModel = document.getElementById('customModel');
@@ -100,6 +101,7 @@ class FormManager {
         openaiKey.required = false;
         ollamaUrl.required = false;
         ollamaModel.required = false;
+        ollamaStructuredOutput.required = false;
         customBaseUrl.required = false;
         customApiKey.required = false;
         customModel.required = false;
@@ -114,6 +116,7 @@ class FormManager {
                 ollamaSettings.classList.remove('hidden');
                 ollamaUrl.required = true;
                 ollamaModel.required = true;
+                ollamaStructuredOutput.required = true;
                 break;
             case 'custom':
                 customSettings.classList.remove('hidden');

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -673,6 +673,7 @@ router.get('/setup', async (req, res) => {
       OPENAI_MODEL: process.env.OPENAI_MODEL || 'gpt-4o-mini',
       OLLAMA_API_URL: process.env.OLLAMA_API_URL || 'http://localhost:11434',
       OLLAMA_MODEL: process.env.OLLAMA_MODEL || 'llama3.2',
+      OLLAMA_STRUCTURED_OUTPUT: process.env.OLLAMA_STRUCTURED_OUTPUT || 'yes',
       SCAN_INTERVAL: process.env.SCAN_INTERVAL || '*/30 * * * *',
       SYSTEM_PROMPT: process.env.SYSTEM_PROMPT || '',
       PROCESS_PREDEFINED_DOCUMENTS: process.env.PROCESS_PREDEFINED_DOCUMENTS || 'no',
@@ -1217,6 +1218,7 @@ router.post('/setup', express.json(), async (req, res) => {
       openaiModel,
       ollamaUrl,
       ollamaModel,
+      ollamaStructuredOutput,
       scanInterval,
       systemPrompt,
       showTags,
@@ -1375,6 +1377,7 @@ router.post('/setup', express.json(), async (req, res) => {
       }
       config.OLLAMA_API_URL = ollamaUrl || 'http://localhost:11434';
       config.OLLAMA_MODEL = ollamaModel || 'llama3.2';
+      config.OLLAMA_STRUCTURED_OUTPUT = ollamaStructuredOutput || 'yes';
     } else if (aiProvider === 'custom') {
       const isCustomValid = await setupService.validateCustomConfig(customBaseUrl, customApiKey, customModel);
       if (!isCustomValid) {
@@ -1421,6 +1424,7 @@ router.post('/settings', express.json(), async (req, res) => {
       openaiModel,
       ollamaUrl,
       ollamaModel,
+      ollamaStructuredOutput,
       scanInterval,
       systemPrompt,
       showTags,
@@ -1556,6 +1560,7 @@ router.post('/settings', express.json(), async (req, res) => {
         }
         if (ollamaUrl) updatedConfig.OLLAMA_API_URL = ollamaUrl;
         if (ollamaModel) updatedConfig.OLLAMA_MODEL = ollamaModel;
+        if (ollamaStructuredOutput) updatedConfig.OLLAMA_STRUCTURED_OUTPUT = ollamaStructuredOutput;
       }
     }
 

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -18,286 +18,36 @@ class OllamaService {
     async analyzeDocument(content, existingTags = [], existingCorrespondentList = [], id, customPrompt = null) {
         const cachePath = path.join('./public/images', `${id}.png`);
         try {
-            const now = new Date();
-            const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
-            //if process.env.CONTENT_MAX_LENGTH is set, truncate the content to the specified length
-            try {
-                if (process.env.CONTENT_MAX_LENGTH) {
-                    console.log('Truncating content to max length:', process.env.CONTENT_MAX_LENGTH);
-                    content = content.substring(0, process.env.CONTENT_MAX_LENGTH);
-                }
-            } catch (error) {
-                console.error('Error truncating content:', error);
-            }
-            let prompt;
-            if(!customPrompt) {
-                prompt = this._buildPrompt(content, existingTags, existingCorrespondentList);
-            }else{
-                prompt = customPrompt + "\n\n" + JSON.stringify(content);
-                console.log('[DEBUG] Ollama Service started with custom prompt');
-            }
-
-
-            // Parse CUSTOM_FIELDS from environment variable
-            let customFieldsObj;
-            try {
-                customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
-            } catch (error) {
-                console.error('Failed to parse CUSTOM_FIELDS:', error);
-                customFieldsObj = { custom_fields: [] };
-            }
-
-            // Generate custom fields template for the prompt
-            const customFieldsTemplate = {};
-
-            customFieldsObj.custom_fields.forEach((field, index) => {
-                customFieldsTemplate[index] = {
-                field_name: field.value,
-                value: "Fill in the value based on your analysis"
-                };
-            });
-
-            // Convert template to string for replacement and wrap in custom_fields
-            const customFieldsStr = '"custom_fields": ' + JSON.stringify(customFieldsTemplate, null, 2)
-                .split('\n')
-                .map(line => '    ' + line)  // Add proper indentation
-                .join('\n');
-
             // Handle thumbnail caching
             try {
                 await fs.access(cachePath);
-                console.log('[DEBUG] Thumbnail already cached');
+                console.debug('Thumbnail already cached');
             } catch (err) {
-                console.log('Thumbnail not cached, fetching from Paperless');  
+                console.info('Thumbnail not cached, fetching from Paperless');
                 const thumbnailData = await paperlessService.getThumbnailImage(id);
-            if (!thumbnailData) {
-                console.warn('Thumbnail nicht gefunden');
-            }
-                await fs.mkdir(path.dirname(cachePath), { recursive: true });
+                if (!thumbnailData) {
+                    console.warn('Thumbnail not found');
+                }
+                await fs.mkdir(path.dirname(cachePath), {recursive: true});
                 await fs.writeFile(cachePath, thumbnailData);
             }
 
-            
-            const getAvailableMemory = async () => {
-                const totalMemory = os.totalmem();
-                const freeMemory = os.freemem();
-                const totalMemoryMB = (totalMemory / (1024 * 1024)).toFixed(0);
-                const freeMemoryMB = (freeMemory / (1024 * 1024)).toFixed(0);
-                return { totalMemoryMB, freeMemoryMB };
-            };
-            
-            const calculateNumCtx = (promptTokenCount, expectedResponseTokens) => {
-                const totalTokenUsage = promptTokenCount + expectedResponseTokens;
-                const maxCtxLimit = 128000;
-                
-                const numCtx = Math.min(totalTokenUsage, maxCtxLimit);
-                
-                console.log('Prompt Token Count:', promptTokenCount);
-                console.log('Expected Response Tokens:', expectedResponseTokens);
-                console.log('Dynamic calculated num_ctx:', numCtx);
-                
-                return numCtx;
-            };
-            
-            const calculatePromptTokenCount = (prompt) => {
-                return Math.ceil(prompt.length / 4);
-            };
-            
-            const { freeMemoryMB } = await getAvailableMemory();
-            const expectedResponseTokens = 1024;
-            const promptTokenCount = calculatePromptTokenCount(prompt);
-            
-            let systemPromptFinal = `
-                    You are a document analyzer. Your task is to analyze documents and extract relevant information. You do not ask back questions. 
-                    YOU MUSTNOT: Ask for additional information or clarification, or ask questions about the document, or ask for additional context.
-                    YOU MUSTNOT: Return a response without the desired JSON format.
-                    YOU MUST: Return the result EXCLUSIVELY as a JSON object. The Tags, Title and Document_Type MUST be in the language that is used in the document.:
-                    IMPORTANT: The custom_fields are optional and can be left out if not needed, only try to fill out the values if you find a matching information in the document.
-                    Do not change the value of field_name, only fill out the values. If the field is about money only add the number without currency and always use a . for decimal places.
-                    {
-                        "title": "xxxxx",
-                        "correspondent": "xxxxxxxx",
-                        "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
-                        "document_type": "Invoice/Contract/...",
-                        "document_date": "YYYY-MM-DD",
-                        "language": "en/de/es/...",
-                        %CUSTOMFIELDS%
-                    }
-                    ALWAYS USE THE INFORMATION TO FILL OUT THE JSON OBJECT. DO NOT ASK BACK QUESTIONS.
-                    `;
-            
-            systemPromptFinal = systemPromptFinal.replace('%CUSTOMFIELDS%', customFieldsStr);
-
-            const numCtx = calculateNumCtx(promptTokenCount, expectedResponseTokens);
-            const response = await this.client.post(`${this.apiUrl}/api/generate`, {
-                model: this.model,
-                prompt: prompt,
-                system: systemPromptFinal,
-                    stream: false,
-                    options: {
-                        temperature: 0.7, 
-                        top_p: 0.9,
-                        repeat_penalty: 1.1,
-                        top_k: 7,
-                        num_predict: 256,
-                        num_ctx: numCtx 
-                    }
-                    //   options: {
-                        //     temperature: 0.3,        // Moderately low for balance between consistency and creativity
-                        //     top_p: 0.7,             // More reasonable value to allow sufficient token diversity
-                        //     repeat_penalty: 1.1,     // Return to original value as 1.2 might be too restrictive
-                        //     top_k: 40,              // Increased from 10 to allow more token options
-                        //     num_predict: 512,        // Reduced from 1024 to a more stable value
-                        //     num_ctx: 2048           // Reduced context window for more stable processing
-                        // }
-                    });
-                    
-                    if (!response.data || !response.data.response) {
-                        throw new Error('Invalid response from Ollama API');
-                    }
-                    
-                    const parsedResponse = this._parseResponse(response.data.response);
-                    //console.log('Ollama response:', parsedResponse);
-                    if(parsedResponse.tags.length === 0 && parsedResponse.correspondent === null) {
-                        console.warn('No tags or correspondent found in response from Ollama for Document.\nPlease review your prompt or switch to OpenAI for better results.',);
-                    }
-                    
-                    await this.writePromptToFile(prompt + "\n\n" + JSON.stringify(parsedResponse));
-                    // Match the OpenAI service response structure
-                    return {
-                        document: parsedResponse,
-                        metrics: {
-                            promptTokens: 0,  // Ollama doesn't provide token metrics
-                            completionTokens: 0,
-                            totalTokens: 0
-                        },
-                        truncated: false
-                    };
-                    
-                } catch (error) {
-                    console.error('Error analyzing document with Ollama:', error);
-                    return {
-                        document: { tags: [], correspondent: null },
-                        metrics: null,
+            const response = await this._postOllamaRequest(content, existingTags, existingCorrespondentList, customPrompt, true);
+            return this._convertToOpenAiResponse(response);
+        } catch (error) {
+            console.error('Error analyzing document with Ollama:', error);
+            return {
+                document: {tags: [], correspondent: null},
+                metrics: null,
                 error: error.message
             };
         }
     }
-    
-    
-    async writePromptToFile(systemPrompt) {
-        const filePath = './logs/prompt.txt';
-        const maxSize = 10 * 1024 * 1024;
-      
+
+    async analyzePlayground(content, existingTags = [], existingCorrespondentList = [], prompt) {
         try {
-          const stats = await fs.stat(filePath);
-          if (stats.size > maxSize) {
-            await fs.unlink(filePath); // Delete the file if is biger 10MB
-          }
-        } catch (error) {
-          if (error.code !== 'ENOENT') {
-            console.warn('[WARNING] Error checking file size:', error);
-          }
-        }
-      
-        try {
-          await fs.appendFile(filePath, '================================================================================' + systemPrompt + '\n\n' + '================================================================================\n\n');
-        } catch (error) {
-          console.error('[ERROR] Error writing to file:', error);
-        }
-      }
-
-    async analyzePlayground(content, prompt) {
-        try {
-
-            const getAvailableMemory = async () => {
-                const totalMemory = os.totalmem();
-                const freeMemory = os.freemem();
-                const totalMemoryMB = (totalMemory / (1024 * 1024)).toFixed(0);
-                const freeMemoryMB = (freeMemory / (1024 * 1024)).toFixed(0);
-                return { totalMemoryMB, freeMemoryMB };
-            };
-            
-            const calculateNumCtx = (promptTokenCount, expectedResponseTokens) => {
-                const totalTokenUsage = promptTokenCount + expectedResponseTokens;
-                const maxCtxLimit = 128000;
-                
-                const numCtx = Math.min(totalTokenUsage, maxCtxLimit);
-                
-                console.log('Prompt Token Count:', promptTokenCount);
-                console.log('Expected Response Tokens:', expectedResponseTokens);
-                console.log('Dynamic calculated num_ctx:', numCtx);
-                
-                return numCtx;
-            };
-            
-            const calculatePromptTokenCount = (prompt) => {
-                return Math.ceil(prompt.length / 4);
-            };
-            
-            const { freeMemoryMB } = await getAvailableMemory();
-            const expectedResponseTokens = 1024;
-            const promptTokenCount = calculatePromptTokenCount(prompt);
-            
-            const numCtx = calculateNumCtx(promptTokenCount, expectedResponseTokens);
-          
-            const response = await this.client.post(`${this.apiUrl}/api/generate`, {
-                model: this.model,
-                prompt: prompt + "\n\n" + JSON.stringify(content),
-                system: `
-                You are a document analyzer. Your task is to analyze documents and extract relevant information. You do not ask back questions. 
-                YOU MUSTNOT: Ask for additional information or clarification, or ask questions about the document, or ask for additional context.
-                YOU MUSTNOT: Return a response without the desired JSON format.
-                YOU MUST: Analyze the document content and extract the following information into this structured JSON format and only this format!:         {
-                "title": "xxxxx",
-                "correspondent": "xxxxxxxx",
-                "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
-                "document_type": "Invoice/Contract/...",
-                "document_date": "YYYY-MM-DD",
-                "language": "en/de/es/..."
-                }
-                ALWAYS USE THE INFORMATION TO FILL OUT THE JSON OBJECT. DO NOT ASK BACK QUESTIONS.
-                `,
-                stream: false,
-                options: {
-                  temperature: 0.7, 
-                  top_p: 0.9,
-                  repeat_penalty: 1.1,
-                  top_k: 7,
-                  num_predict: 256,
-                  num_ctx: numCtx
-                }
-              //   options: {
-              //     temperature: 0.3,        // Moderately low for balance between consistency and creativity
-              //     top_p: 0.7,             // More reasonable value to allow sufficient token diversity
-              //     repeat_penalty: 1.1,     // Return to original value as 1.2 might be too restrictive
-              //     top_k: 40,              // Increased from 10 to allow more token options
-              //     num_predict: 512,        // Reduced from 1024 to a more stable value
-              //     num_ctx: 2048           // Reduced context window for more stable processing
-              // }
-            });
-
-            if (!response.data || !response.data.response) {
-                throw new Error('Invalid response from Ollama API');
-            }
-
-            const parsedResponse = this._parseResponse(response.data.response);
-            //console.log('Ollama response:', parsedResponse);
-            if(parsedResponse.tags.length === 0 && parsedResponse.correspondent === null) {
-                console.warn('No tags or correspondent found in response from Ollama for Document.\nPlease review your prompt or switch to OpenAI for better results.',);
-            }
-
-            // Match the OpenAI service response structure
-            return {
-                document: parsedResponse,
-                metrics: {
-                    promptTokens: 0,  // Ollama doesn't provide token metrics
-                    completionTokens: 0,
-                    totalTokens: 0
-                },
-                truncated: false
-            };
-
+            const response = await this._postOllamaRequest(content, existingTags, existingCorrespondentList, prompt);
+            return this._convertToOpenAiResponse(response);
         } catch (error) {
             console.error('Error analyzing document with Ollama:', error);
             return {
@@ -308,22 +58,23 @@ class OllamaService {
         }
     }
 
-    _buildPrompt(content, existingTags = [], existingCorrespondent = []) {
-        let systemPrompt;
-        let promptTags = '';
-    
-        // Validate that existingCorrespondent is an array and handle if it's not
-        const correspondentList = Array.isArray(existingCorrespondent) 
-            ? existingCorrespondent 
-            : [];
-    
-        if (process.env.USE_PROMPT_TAGS === 'yes') {
-            promptTags = process.env.PROMPT_TAGS;
-            systemPrompt = config.specialPromptPreDefinedTags;
-        } else {
-            systemPrompt = process.env.SYSTEM_PROMPT + '\n\n' + config.mustHavePrompt;
+    _buildSystemPrompt(existingTags = [], existingCorrespondent = [], prompt = null) {
+        let systemPrompt = '';
+
+        if (prompt) {
+            console.debug('Replace system prompt with custom prompt');
+            systemPrompt = prompt + '\n\n';
         }
-    
+        else {
+            systemPrompt = process.env.SYSTEM_PROMPT + '\n\n';
+        }
+
+        if (process.env.USE_PROMPT_TAGS === 'yes') {
+            systemPrompt += config.specialPromptPreDefinedTags.replace('%CUSTOMFIELDS%', this._getCustomFields());
+        } else {
+            systemPrompt += config.mustHavePrompt.replace('%CUSTOMFIELDS%', this._getCustomFields());
+        }
+
         // Format existing tags
         const existingTagsList = Array.isArray(existingTags)
             ? existingTags
@@ -331,29 +82,27 @@ class OllamaService {
                 .map(tag => tag.name)
                 .join(', ')
             : '';
-    
+
         // Format existing correspondents - handle both array of objects and array of strings
-        const existingCorrespondentList = correspondentList
-            .filter(Boolean)  // Remove any null/undefined entries
-            .map(correspondent => {
-                if (typeof correspondent === 'string') return correspondent;
-                return correspondent?.name || '';
-            })
-            .filter(name => name.length > 0)  // Remove empty strings
-            .join(', ');
+        const existingCorrespondentList =  Array.isArray(existingCorrespondent)
+            ? existingCorrespondent
+                .filter(Boolean)  // Remove any null/undefined entries
+                .map(correspondent => {
+                    if (typeof correspondent === 'string') return correspondent;
+                    return correspondent?.name || '';
+                })
+                .filter(name => name.length > 0)  // Remove empty strings
+                .join(', ')
+            : '';
     
-        if(process.env.USE_EXISTING_DATA === 'yes') {
-            return `${systemPrompt}
-            Existing tags: ${existingTagsList}\n
-            Existing Correspondents: ${existingCorrespondentList}\n
-            ${JSON.stringify(content)}
-            
-            `;
-        }else {
-            return `${systemPrompt}
-            ${JSON.stringify(content)}
-            `;
+        if (process.env.USE_EXISTING_DATA === 'yes') {
+            systemPrompt = `
+                Existing tags: ${existingTagsList}\n\n
+                Existing Correspondents: ${existingCorrespondentList}\n\n
+                ${systemPrompt}`;
         }
+
+        return systemPrompt;
     }
 
     _parseResponse(response) {
@@ -383,8 +132,8 @@ class OllamaService {
                   custom_fields: result.custom_fields || null
               };
   
-          } catch (errorx) {
-              console.warn('Error parsing JSON from response:', errorx.message);
+          } catch (error) {
+              console.warn('Error parsing JSON from response:', error.message);
               console.warn('Attempting to sanitize the JSON...');
   
               // Optionally sanitize the JSON here
@@ -414,6 +163,150 @@ class OllamaService {
           return { tags: [], correspondent: null };
       }
   }
+
+    _truncateContent(content) {
+        // if process.env.CONTENT_MAX_LENGTH is set, truncate the content to the specified length
+        try {
+            if (process.env.CONTENT_MAX_LENGTH) {
+                console.log('Truncating content to max length:', process.env.CONTENT_MAX_LENGTH);
+                content = content.substring(0, process.env.CONTENT_MAX_LENGTH);
+            }
+        } catch (error) {
+            console.error('Error truncating content:', error);
+        }
+        return content;
+    }
+
+    _getCustomFields() {
+        // Parse CUSTOM_FIELDS from environment variable
+        let customFieldsObj;
+        try {
+            customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
+        } catch (error) {
+            console.error('Failed to parse CUSTOM_FIELDS:', error);
+            customFieldsObj = { custom_fields: [] };
+        }
+
+        // Generate custom fields template for the prompt
+        const customFieldsTemplate = {};
+
+        customFieldsObj.custom_fields.forEach((field, index) => {
+            customFieldsTemplate[index] = {
+                field_name: field.value,
+                value: "Fill in the value based on your analysis"
+            };
+        });
+
+        // Convert template to string for replacement and wrap in custom_fields
+        const customFieldsStr = '"custom_fields": ' + JSON.stringify(customFieldsTemplate, null, 2)
+            .split('\n')
+            .map(line => '    ' + line)  // Add proper indentation
+            .join('\n');
+
+        return customFieldsStr;
+    }
+
+    _calculatePromptTokenCount(prompt) {
+        return Math.ceil(prompt.length / 4);
+    }
+
+    _calculateNumCtx(prompt, expectedResponseTokens) {
+        const promptTokenCount = this._calculatePromptTokenCount(prompt);
+        const totalTokenUsage = promptTokenCount + expectedResponseTokens;
+        const maxCtxLimit = 128000;
+
+        const numCtx = Math.min(totalTokenUsage, maxCtxLimit);
+
+        console.log('Prompt Token Count:', promptTokenCount);
+        console.log('Expected Response Tokens:', expectedResponseTokens);
+        console.log('Dynamic calculated num_ctx:', numCtx);
+
+        return numCtx;
+    }
+
+    async _writePromptToFile(systemPrompt) {
+        const filePath = './logs/prompt.txt';
+        const maxSize = 10 * 1024 * 1024;
+
+        try {
+            const stats = await fs.stat(filePath);
+            if (stats.size > maxSize) {
+                await fs.unlink(filePath); // Delete the file if is biger 10MB
+            }
+        } catch (error) {
+            if (error.code !== 'ENOENT') {
+                console.warn('[WARNING] Error checking file size:', error);
+            }
+        }
+
+        try {
+            await fs.appendFile(filePath, '================================================================================' + systemPrompt + '\n\n' + '================================================================================\n\n');
+        } catch (error) {
+            console.error('[ERROR] Error writing to file:', error);
+        }
+    }
+
+    async _postOllamaRequest(content, existingTags = [], existingCorrespondent = [], customPrompt = null, writeToFile = false) {
+        const systemPrompt = this._buildSystemPrompt(existingTags, existingCorrespondent, customPrompt);
+        const expectedResponseTokens = 1024;
+        const numCtx = this._calculateNumCtx(content, expectedResponseTokens);
+        const truncatedContent = this._truncateContent(content);
+        console.debug('Ollama Request:',
+            `\nSystem Prompt: ${systemPrompt}\nPrompt: ${truncatedContent}\nnum_ctx: ${numCtx}`)
+
+        const response = await this.client.post(`${this.apiUrl}/api/generate`, {
+            model: this.model,
+            prompt: truncatedContent,
+            system: systemPrompt,
+            stream: false,
+            options: {
+                temperature: 0.7,
+                top_p: 0.9,
+                repeat_penalty: 1.1,
+                top_k: 7,
+                num_predict: 256,
+                num_ctx: numCtx
+            }
+            //   options: {
+            //     temperature: 0.3,        // Moderately low for balance between consistency and creativity
+            //     top_p: 0.7,             // More reasonable value to allow sufficient token diversity
+            //     repeat_penalty: 1.1,     // Return to original value as 1.2 might be too restrictive
+            //     top_k: 40,              // Increased from 10 to allow more token options
+            //     num_predict: 512,        // Reduced from 1024 to a more stable value
+            //     num_ctx: 2048           // Reduced context window for more stable processing
+            // }
+        });
+
+        if (!response.data || !response.data.response) {
+            throw new Error('Invalid response from Ollama API');
+        }
+        console.debug('Ollama response:', response.data.response);
+
+        const parsedResponse = this._parseResponse(response.data.response);
+        console.debug('Ollama response (parsed):', parsedResponse);
+
+        if (writeToFile) {
+            await this._writePromptToFile(systemPrompt + "\n\n" + truncatedContent + "\n\n" + JSON.stringify(parsedResponse));
+        }
+
+        if (parsedResponse.tags.length === 0 && parsedResponse.correspondent === null) {
+            console.warn('No tags or correspondent found in response from Ollama for Document.\nPlease review your prompt or switch to OpenAI for better results.',);
+        }
+
+        return parsedResponse;
+    }
+
+    _convertToOpenAiResponse(ollamaResponse) {
+        return {
+            document: ollamaResponse,
+            metrics: {
+                promptTokens: 0, // Ollama doesn't provide token metrics
+                completionTokens: 0,
+                totalTokens: 0
+            },
+            truncated: false
+        }
+    }
 }
 
 module.exports = new OllamaService();

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -62,19 +62,11 @@ class OllamaService {
     _buildSystemPrompt(existingTags = [], existingCorrespondent = [], prompt = null) {
         let systemPrompt = '';
 
-        if (prompt) {
-            console.debug('Replace system prompt with custom prompt');
-            systemPrompt = prompt + '\n\n';
-        }
-        else {
-            systemPrompt = process.env.SYSTEM_PROMPT + '\n\n';
-        }
-
         if (this.structuredOutput === 'yes') {
             if (process.env.USE_PROMPT_TAGS === 'yes') {
-                systemPrompt += config.specialPromptPreDefinedTagsWithoutJson;
+                systemPrompt = config.specialPromptPreDefinedTagsWithoutJson;
             } else {
-                systemPrompt += config.mustHavePromptWithoutJson;
+                systemPrompt = config.mustHavePromptWithoutJson;
             }
         } else {
             if (process.env.USE_PROMPT_TAGS === 'yes') {
@@ -105,10 +97,18 @@ class OllamaService {
             : '';
     
         if (process.env.USE_EXISTING_DATA === 'yes') {
-            systemPrompt = `
-                Existing tags: ${existingTagsList}\n\n
-                Existing Correspondents: ${existingCorrespondentList}\n\n
-                ${systemPrompt}`;
+            systemPrompt = `${systemPrompt}
+                ${config.existingDataPrompt}
+                Existing tags: ${existingTagsList}
+                Existing Correspondents: ${existingCorrespondentList}`;
+        }
+
+        if (prompt) {
+            console.debug('Replace system prompt with custom prompt');
+            systemPrompt += "\n\n" + prompt;
+        }
+        else {
+            systemPrompt += "\n\n" + process.env.SYSTEM_PROMPT;
         }
 
         return systemPrompt;

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -309,8 +309,8 @@ class OllamaService {
         const expectedResponseTokens = 1024;
         const numCtx = this._calculateNumCtx(content, expectedResponseTokens);
         const truncatedContent = this._truncateContent(content);
-        console.debug('Ollama Request:',
-            `\nSystem Prompt: ${systemPrompt}\n\nPrompt: ${truncatedContent}\n\nnum_ctx: ${numCtx}\n\nFormat: ${JSON.stringify(format)}`)
+        // console.debug('Ollama Request:',
+        //    `\nSystem Prompt: ${systemPrompt}\n\nPrompt: ${truncatedContent}\n\nnum_ctx: ${numCtx}\n\nFormat: ${JSON.stringify(format)}`)
 
         const response = await this.client.post(`${this.apiUrl}/api/generate`, {
             model: this.model,
@@ -339,10 +339,10 @@ class OllamaService {
         if (!response.data || !response.data.response) {
             throw new Error('Invalid response from Ollama API');
         }
-        console.debug('Ollama response:', response.data.response);
+        // console.debug('Ollama response:', response.data.response);
 
         const parsedResponse = this._parseResponse(response.data.response);
-        console.debug('Ollama response (parsed):', parsedResponse);
+        // console.debug('Ollama response (parsed):', parsedResponse);
 
         if (writeToFile) {
             await this._writePromptToFile(systemPrompt + "\n\n" + truncatedContent + "\n\n" + JSON.stringify(parsedResponse));

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -303,6 +303,17 @@
                                             value="<%= config.OLLAMA_MODEL %>"
                                             class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                                     </div>
+
+                                    <div class="space-y-2">
+                                        <label for="ollamaStructuredOutput" class="text-sm font-medium">Use Ollama structured outputs?</label>
+                                        <select id="ollamaStructuredOutput"
+                                                name="ollamaStructuredOutput"
+                                                class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                            <option value="no" <%= config.OLLAMA_STRUCTURED_OUTPUT === 'no' ? 'selected' : '' %>>No</option>
+                                            <option value="yes" <%= config.OLLAMA_STRUCTURED_OUTPUT === 'yes' ? 'selected' : '' %>>Yes</option>
+                                        </select>
+                                        <p class="text-sm text-gray-500">Structured outputs requires Ollama 0.5.0 or later.</p>
+                                    </div>
                                 </div>
 
                                 <!-- Custom Provider Settings -->

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -256,6 +256,18 @@
                                                    value="<%= config.OLLAMA_MODEL %>"
                                                    class="modern-input">
                                         </div>
+
+                                        <div class="form-group">
+                                            <label for="ollamaStructuredOutput">Use Ollama structured outputs?</label>
+                                            <select id="ollamaStructuredOutput"
+                                                    name="ollamaStructuredOutput"
+                                                    class="modern-input">
+                                                <option value="no" <%= config.OLLAMA_STRUCTURED_OUTPUT === 'no' ? 'selected' : '' %>>No</option>
+                                                <option value="yes" <%= config.OLLAMA_STRUCTURED_OUTPUT === 'yes' ? 'selected' : '' %>>Yes</option>
+                                                <p class="text-sm text-gray-500">Structured outputs requires Ollama 0.5.0 or later.</p>
+                                                <p class="help-text">Structured outputs requires Ollama 0.5.0 or later.</p>
+                                            </select>
+                                        </div>
                                     </div>
 
                                     <!-- Custom Provider Settings -->


### PR DESCRIPTION
Newer models require Ollama's structured output feature to define the json structure of the response (see https://ollama.com/blog/structured-outputs)

This allows to use DeepSeek with Ollama in Paperless AI.

I have tested the changes with
- hf.co/unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q6_K
- llama3.1

and this prompt
```
Important rules for the analysis:

For tags:
- FIRST check the tags from the following list before suggesting new ones: Tag1, Tag2, ...
- Use only relevant categories
- Maximum 4 tags per document, less if sufficient (at least 1)
- Avoid generic or too specific tags
- Use only the most important information for tag creation
- You MUST NOT add details like invoice/order number to the tag
- The output language is the one used in the document! IMPORTANT!

For title:
- Short and concise, NO ADDRESSES
- Contains the most important identification features
- For invoices/orders, mention invoice/order number if available
- The output language is the one used in the document! IMPORTANT!

For correspondent:
- Identify the sender or institution
- When generating the correspondent, always create the shortest possible form of the company name (e.g. "Amazon" instead of "Amazon EU SARL, German branch")
- You MUST NOT add addresses!

For document_date:
- Extract the date of the document (format: YYYY-MM-DD)
- If multiple dates are present, use the most relevant one

For document_type:
- You MUST only use document_type from the following list: Type1, Type2, ...
- If no document_type from the list is applicable, do not add document_type to the response

For Empfänger:
- Identify one or more recipients 
- You MUST only use recipients from the following list: Name1, Name2, ...
- You MUST NOT add surename, middle names, salutation or title (e.g. "Christian" instead of "Herr Christian Anton Mustermann")
- You MUST NOT add addresses!

Für Gesamtbetrag:
- Identify the total invoice amount
- Return the value only without currency
```

My next step will be - unless @clusterzx disagrees - to align the three AI services with a parent service and overwrite the required functions only to get rid of a lot of duplicate code