### PR TITLE
Playground improvements

### DIFF
--- a/public/js/playground-analyzer.js
+++ b/public/js/playground-analyzer.js
@@ -612,8 +612,6 @@ class PlaygroundAnalyzer {
                 },
                 body: JSON.stringify({
                     content: contentData.content,
-                    existingTags: existingTags.map(t => t.id),
-                    correspondent: existingCorrespondent,
                     prompt: prompt,
                     documentId: docId
                 })

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -179,6 +179,7 @@ router.get('/playground', protectApiRoute, async (req, res) => {
       documents,
       tagNames,
       correspondentNames,
+      documentTypes,
       paperlessUrl
     } = await documentsService.getDocumentsWithMetadata(numberOfDocuments);
 
@@ -186,6 +187,7 @@ router.get('/playground', protectApiRoute, async (req, res) => {
       documents,
       tagNames,
       correspondentNames,
+      documentTypes,
       paperlessUrl,
       version: configFile.PAPERLESS_AI_VERSION || ' '
     });

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1088,7 +1088,8 @@ router.post('/manual/analyze', express.json(), async (req, res) => {
 
 router.post('/manual/playground', express.json(), async (req, res) => {
   try {
-    const { content, existingTags, prompt, documentId } = req.body;
+    const { content, prompt, documentId } = req.body;
+    let existingTags = await paperlessService.getTags();
     let existingCorrespondentList = await paperlessService.listCorrespondentsNames();
     existingCorrespondentList = existingCorrespondentList.map(correspondent => correspondent.name);
     

--- a/services/documentsService.js
+++ b/services/documentsService.js
@@ -27,9 +27,9 @@ class DocumentsService {
     return Object.fromEntries(this.correspondentCache);
   }
 
-  async getDocumentsWithMetadata() {
+  async getDocumentsWithMetadata(numberOfDocuments = -1) {
     const [documents, tagNames, correspondentNames] = await Promise.all([
-      paperlessService.getDocuments(),
+      paperlessService.getDocuments(numberOfDocuments),
       this.getTagNames(),
       this.getCorrespondentNames()
     ]);

--- a/services/documentsService.js
+++ b/services/documentsService.js
@@ -5,6 +5,7 @@ class DocumentsService {
   constructor() {
     this.tagCache = new Map();
     this.correspondentCache = new Map();
+    this.documentTypeCache = new Map();
   }
 
   async getTagNames() {
@@ -27,11 +28,22 @@ class DocumentsService {
     return Object.fromEntries(this.correspondentCache);
   }
 
+  async getDocumentTypes() {
+    if (this.documentTypeCache.size === 0) {
+      const documentTypes = await paperlessService.listDocumentTypes();
+      documentTypes.forEach(documentType => {
+        this.documentTypeCache.set(documentType.id, documentType.name);
+      })
+    }
+    return Object.fromEntries(this.documentTypeCache);
+  }
+
   async getDocumentsWithMetadata(numberOfDocuments = -1) {
-    const [documents, tagNames, correspondentNames] = await Promise.all([
+    const [documents, tagNames, correspondentNames, documentTypes] = await Promise.all([
       paperlessService.getDocuments(numberOfDocuments),
       this.getTagNames(),
-      this.getCorrespondentNames()
+      this.getCorrespondentNames(),
+      this.getDocumentTypes()
     ]);
 
     // Sort documents by created date (newest first)
@@ -41,6 +53,7 @@ class DocumentsService {
       documents,
       tagNames,
       correspondentNames,
+      documentTypes,
       paperlessUrl: process.env.PAPERLESS_API_URL.replace('/api', '')
     };
   }

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -469,6 +469,50 @@ class PaperlessService {
     }
   }
 
+  async listDocumentTypes() {
+    this.initialize();
+    let documentTypes = [];
+    let page = 1;
+    let hasNextPage = true;
+
+    try {
+      while (hasNextPage) {
+        const response = await this.client.get('/document_types/', {
+          params: {
+            fields: 'id,name',
+            count: true,
+            page: page
+          }
+        });
+
+        const { results, next } = response.data;
+
+        documentTypes = documentTypes.concat(
+            results.map(documentType => ({
+              name: documentType.name,
+              id: documentType.id,
+              document_count: documentType.document_count
+            }))
+        );
+
+        // Prüfe, ob es eine nächste Seite gibt
+        hasNextPage = next !== null;
+        page++;
+
+        // Optional: Füge eine kleine Verzögerung hinzu, um die API nicht zu überlasten
+        if (hasNextPage) {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+      }
+
+      return documentTypes;
+
+    } catch (error) {
+      console.error('[ERROR] fetching document types:', error.message);
+      return [];
+    }
+  }
+
   async listTagNames() {
     this.initialize();
     let allTags = [];
@@ -550,7 +594,7 @@ class PaperlessService {
         const params = {
           page,
           page_size: numberOfDocuments > 0 ? numberOfDocuments : 100,
-          fields: 'id,title,created,created_date,added,tags,correspondent'
+          fields: 'id,title,created,created_date,added,tags,correspondent,document_type'
         };
 
         // Füge Tag-Filter hinzu, wenn Tags definiert sind

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -506,7 +506,7 @@ class PaperlessService {
     }
   }
   
-  async getAllDocuments() {
+  async getAllDocuments(numberOfDocuments = -1) {
     this.initialize();
     if (!this.client) {
       console.error('[DEBUG] Client not initialized');
@@ -549,7 +549,7 @@ class PaperlessService {
       try {
         const params = {
           page,
-          page_size: 100,
+          page_size: numberOfDocuments > 0 ? numberOfDocuments : 100,
           fields: 'id,title,created,created_date,added,tags,correspondent'
         };
 
@@ -570,7 +570,7 @@ class PaperlessService {
         }
 
         documents = documents.concat(response.data.results);
-        hasMore = response.data.next !== null;
+        hasMore = numberOfDocuments < 0 && response.data.next !== null;
         page++;
 
         console.log(
@@ -763,8 +763,8 @@ class PaperlessService {
 
 
   // Aktualisierte getDocuments Methode
-  async getDocuments() {
-    return this.getAllDocuments();
+  async getDocuments(numberOfDocuments = -1) {
+    return this.getAllDocuments(numberOfDocuments);
   }
 
   async getDocumentContent(documentId) {

--- a/views/playground.ejs
+++ b/views/playground.ejs
@@ -151,17 +151,22 @@
                                         <h3 class="text-sm font-medium truncate"><%= doc.title %></h3>
                                     </div>
                                     
-                                    <div class="info-item">
-                                        <p class="text-xs text-gray-600 truncate">
+                                    <div class="info-item info-item-meta">
+                                        <p class="text-xs text-gray-600 truncate"
+                                           data-document_date="<%= new Date(doc.created).valueOf() %>">
                                             <%= new Date(doc.created).toLocaleDateString() %>
                                         </p>
                                         
-                                        <% if (doc.correspondent) { %>
-                                        <p class="text-xs text-gray-600 truncate" 
+                                        <p class="text-xs text-gray-600 truncate"
                                            data-correspondent="<%= doc.correspondent %>">
-                                            <%= correspondentNames[doc.correspondent] || 'Unknown' %>
+                                            Correspondent: <%= correspondentNames[doc.correspondent] || 'Unknown' %>
                                         </p>
-                                        <% } %>
+
+                                        <p class="text-xs text-gray-600 truncate"
+                                           data-document_type="<%= doc.document_type %>">
+                                            Document type: <%= documentTypes[doc.document_type] || 'Unknown' %>
+                                        </p>
+
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Show all information that is returned by the AI in the playground cards. Also align the functionality of playground with the one used in batch. This works only with Ollama together with #381, OpenAI and custom is on my TODO list. Settings are currently ignored as well, it displays everything even if certain fields are disabled for processing