### PR TITLE
Add a configurable token limitation and response size

### DIFF
--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -2165,6 +2165,16 @@
                     "description": "Custom system prompt for document analysis",
                     "example": "Extract key information from the following document..."
                   },
+                  "tokenLimit": {
+                    "type": "integer",
+                    "description": "The maximum number of tokens the AI can handle",
+                    "example": 128000
+                  },
+                  "responseTokens": {
+                    "type": "integer",
+                    "description": "The approximate amount of tokens required for the response",
+                    "example": 1000
+                  },
                   "showTags": {
                     "type": "boolean",
                     "description": "Whether to show tags in the UI",
@@ -3043,6 +3053,16 @@
                     "type": "string",
                     "description": "Model name for custom LLM provider",
                     "example": "custom-model"
+                  },
+                  "tokenLimit": {
+                    "type": "integer",
+                    "description": "The maximum number of tokens the AI can handle",
+                    "example": 128000
+                  },
+                  "responseTokens": {
+                    "type": "integer",
+                    "description": "The approximate amount of tokens required for the response",
+                    "example": 1000
                   },
                   "scanInterval": {
                     "type": "number",

--- a/config/config.js
+++ b/config/config.js
@@ -30,6 +30,8 @@ module.exports = {
   CONFIGURED: false,
   disableAutomaticProcessing: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
   predefinedMode: process.env.PROCESS_PREDEFINED_DOCUMENTS,
+  tokenLimit: process.env.TOKEN_LIMIT || 128000,
+  responseTokens: process.env.RESPONSE_TOKENS || 1000,
   addAIProcessedTag: process.env.ADD_AI_PROCESSED_TAG || 'no',
   addAIProcessedTags: process.env.AI_PROCESSED_TAG_NAME || 'ai-processed',
   paperless: {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -32,6 +32,8 @@ class FormManager {
     constructor() {
         this.form = document.getElementById('setupForm');
         this.aiProvider = document.getElementById('aiProvider');
+        this.tokenLimit = document.getElementById('tokenLimit'); 
+        this.responseTokens = document.getElementById('responseTokens'); 
         this.showTags = document.getElementById('showTags');
         this.aiProcessedTag = document.getElementById('aiProcessedTag');
         this.usePromptTags = document.getElementById('usePromptTags');
@@ -47,6 +49,8 @@ class FormManager {
         this.handleDisableAutomaticProcessing();
         
         this.aiProvider.addEventListener('change', () => this.toggleProviderSettings());
+        this.tokenLimit.addEventListener('input', () => this.validateTokenLimit()); 
+        this.responseTokens.addEventListener('input', () => this.validateResponseTokens()); 
         this.showTags.addEventListener('change', () => this.toggleTagsInput());
         this.aiProcessedTag.addEventListener('change', () => this.toggleAiTagInput());
         this.usePromptTags.addEventListener('change', () => this.togglePromptTagsInput());
@@ -60,6 +64,24 @@ class FormManager {
         
         this.toggleAiTagInput();
         this.togglePromptTagsInput();
+    }
+
+    validateTokenLimit() {
+        const value = parseInt(this.tokenLimit.value, 10);
+        if (isNaN(value) || value < 1) {
+            this.tokenLimit.setCustomValidity('Token Limit must be a positive integer.');
+        } else {
+            this.tokenLimit.setCustomValidity('');
+        }
+    }
+
+    validateResponseTokens() {
+        const value = parseInt(this.responseTokens.value, 10);
+        if (isNaN(value) || value < 0) {
+            this.responseTokens.setCustomValidity('Response tokens must be a non-negative integer.');
+        } else {
+            this.responseTokens.setCustomValidity('');
+        }
     }
 
     handleDisableAutomaticProcessing() {
@@ -95,6 +117,7 @@ class FormManager {
         const azureEndpoint = document.getElementById('azureEndpoint');
         const azureDeploymentName = document.getElementById('azureDeploymentName');
         const azureApiVersion = document.getElementById('azureApiVersion');
+        
         
         // Hide all settings sections first
         openaiSettings.classList.add('hidden');

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1844,6 +1844,8 @@ router.get('/setup', async (req, res) => {
       SCAN_INTERVAL: process.env.SCAN_INTERVAL || '*/30 * * * *',
       SYSTEM_PROMPT: process.env.SYSTEM_PROMPT || '',
       PROCESS_PREDEFINED_DOCUMENTS: process.env.PROCESS_PREDEFINED_DOCUMENTS || 'no',
+      TOKEN_LIMIT: process.env.TOKEN_LIMIT || 128000,
+      RESPONSE_TOKENS: process.env.RESPONSE_TOKENS || 1000,
       TAGS: normalizeArray(process.env.TAGS),
       ADD_AI_PROCESSED_TAG: process.env.ADD_AI_PROCESSED_TAG || 'no',
       AI_PROCESSED_TAG_NAME: process.env.AI_PROCESSED_TAG_NAME || 'ai-processed',
@@ -2636,6 +2638,9 @@ router.get('/settings', async (req, res) => {
     SCAN_INTERVAL: process.env.SCAN_INTERVAL || '*/30 * * * *',
     SYSTEM_PROMPT: process.env.SYSTEM_PROMPT || '',
     PROCESS_PREDEFINED_DOCUMENTS: process.env.PROCESS_PREDEFINED_DOCUMENTS || 'no',
+    
+    TOKEN_LIMIT: process.env.TOKEN_LIMIT || 128000,
+    RESPONSE_TOKENS: process.env.RESPONSE_TOKENS || 1000,
     TAGS: normalizeArray(process.env.TAGS),
     ADD_AI_PROCESSED_TAG: process.env.ADD_AI_PROCESSED_TAG || 'no',
     AI_PROCESSED_TAG_NAME: process.env.AI_PROCESSED_TAG_NAME || 'ai-processed',
@@ -3527,6 +3532,8 @@ router.post('/setup', express.json(), async (req, res) => {
       scanInterval,
       systemPrompt,
       showTags,
+      tokenLimit,
+      responseTokens,
       tags,
       aiProcessedTag,
       aiTagName,
@@ -3644,6 +3651,8 @@ router.post('/setup', express.json(), async (req, res) => {
       SCAN_INTERVAL: scanInterval || '*/30 * * * *',
       SYSTEM_PROMPT: processedPrompt,
       PROCESS_PREDEFINED_DOCUMENTS: showTags || 'no',
+      TOKEN_LIMIT: tokenLimit || 128000,
+      RESPONSE_TOKENS: responseTokens || 1000,
       TAGS: normalizeArray(tags),
       ADD_AI_PROCESSED_TAG: aiProcessedTag || 'no',
       AI_PROCESSED_TAG_NAME: aiTagName || 'ai-processed',
@@ -3814,6 +3823,14 @@ router.post('/setup', express.json(), async (req, res) => {
  *                 type: boolean
  *                 description: Whether to show tags in the UI
  *                 example: true
+ *               tokenLimit:
+ *                 type: integer
+ *                 description: The maximum number of tokens th AI can handle
+ *                 example: 128000
+ *               responseTokens:
+ *                 type: integer
+ *                 description: The approx. amount of tokens required for the response
+ *                 example: 1000
  *               tags:
  *                 type: string
  *                 description: Comma-separated list of tags to use for filtering
@@ -3923,6 +3940,8 @@ router.post('/settings', express.json(), async (req, res) => {
       scanInterval,
       systemPrompt,
       showTags,
+      tokenLimit,
+      responseTokens,
       tags,
       aiProcessedTag,
       aiTagName,
@@ -3964,6 +3983,8 @@ router.post('/settings', express.json(), async (req, res) => {
       SCAN_INTERVAL: process.env.SCAN_INTERVAL || '*/30 * * * *',
       SYSTEM_PROMPT: process.env.SYSTEM_PROMPT || '',
       PROCESS_PREDEFINED_DOCUMENTS: process.env.PROCESS_PREDEFINED_DOCUMENTS || 'no',
+      TOKEN_LIMIT: process.env.TOKEN_LIMIT || 128000,
+      RESPONSE_TOKENS: process.env.RESPONSE_TOKENS || 1000,
       TAGS: process.env.TAGS || '',
       ADD_AI_PROCESSED_TAG: process.env.ADD_AI_PROCESSED_TAG || 'no',
       AI_PROCESSED_TAG_NAME: process.env.AI_PROCESSED_TAG_NAME || 'ai-processed',
@@ -4081,6 +4102,8 @@ router.post('/settings', express.json(), async (req, res) => {
     if (scanInterval) updatedConfig.SCAN_INTERVAL = scanInterval;
     if (systemPrompt) updatedConfig.SYSTEM_PROMPT = processedPrompt.replace(/\r\n/g, '\n').replace(/\n/g, '\\n');
     if (showTags) updatedConfig.PROCESS_PREDEFINED_DOCUMENTS = showTags;
+    if (tokenLimit) updatedConfig.TOKEN_LIMIT = tokenLimit;
+    if (responseTokens) updatedConfig.RESPONSE_TOKENS = responseTokens;
     if (tags !== undefined) updatedConfig.TAGS = normalizeArray(tags);
     if (aiProcessedTag) updatedConfig.ADD_AI_PROCESSED_TAG = aiProcessedTag;
     if (aiTagName) updatedConfig.AI_PROCESSED_TAG_NAME = aiTagName;

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -172,8 +172,8 @@ class AzureOpenAIService {
         process.env.USE_PROMPT_TAGS === 'yes' ? [promptTags] : []
       );
       
-      const maxTokens = 128000;
-      const reservedTokens = totalPromptTokens + 1000;
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens);
       const availableTokens = maxTokens - reservedTokens;
       
       const truncatedContent = await this.truncateToTokenLimit(content, availableTokens);
@@ -211,6 +211,8 @@ class AzureOpenAIService {
 
       let jsonContent = response.choices[0].message.content;
       jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+      // console.log(`[DEBUG] [${timestamp}] Response: ${jsonContent}`);
 
       let parsedResponse;
       try {
@@ -291,8 +293,8 @@ class AzureOpenAIService {
       );
       
       // Calculate available tokens
-      const maxTokens = 128000;
-      const reservedTokens = totalPromptTokens + 1000; // Reserve for response
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens); 
       const availableTokens = maxTokens - reservedTokens;
       
       // Truncate content if necessary

--- a/services/customService.js
+++ b/services/customService.js
@@ -122,8 +122,8 @@ class CustomOpenAIService {
       );
         
         // Calculate available tokens
-        const maxTokens = 128000; // Model's maximum context length
-        const reservedTokens = totalPromptTokens + 1000; // Reserve for response
+        const maxTokens = Number(config.tokenLimit); // Model's maximum context length
+        const reservedTokens = totalPromptTokens +  Number(config.responseTokens); 
         const availableTokens = maxTokens - reservedTokens;
         
         // Truncate content if necessary
@@ -240,8 +240,8 @@ class CustomOpenAIService {
       );
       
       // Calculate available tokens
-      const maxTokens = 128000;
-      const reservedTokens = totalPromptTokens + 1000; // Reserve for response
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens); 
       const availableTokens = maxTokens - reservedTokens;
       
       // Truncate content if necessary

--- a/services/manualService.js
+++ b/services/manualService.js
@@ -216,7 +216,7 @@ class ManualService {
         
         const calculateNumCtx = (promptTokenCount, expectedResponseTokens) => {
             const totalTokenUsage = promptTokenCount + expectedResponseTokens;
-            const maxCtxLimit = 128000;
+            const maxCtxLimit = Number(config.tokenLimit);
             
             const numCtx = Math.min(totalTokenUsage, maxCtxLimit);
             

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -347,7 +347,7 @@ class OllamaService {
      */
     _calculateNumCtx(promptTokenCount, expectedResponseTokens) {
         const totalTokenUsage = promptTokenCount + expectedResponseTokens;
-        const maxCtxLimit = 128000;
+        const maxCtxLimit = Number(config.tokenLimit);
         
         const numCtx = Math.min(totalTokenUsage, maxCtxLimit);
         

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -163,8 +163,8 @@ class OpenAIService {
         process.env.USE_PROMPT_TAGS === 'yes' ? [promptTags] : []
       );
       
-      const maxTokens = 128000;
-      const reservedTokens = totalPromptTokens + 1000;
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens);
       const availableTokens = maxTokens - reservedTokens;
       
       const truncatedContent = await this.truncateToTokenLimit(content, availableTokens);
@@ -282,8 +282,8 @@ class OpenAIService {
       );
       
       // Calculate available tokens
-      const maxTokens = 128000;
-      const reservedTokens = totalPromptTokens + 1000; // Reserve for response
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens); // Reserve for response
       const availableTokens = maxTokens - reservedTokens;
       
       // Truncate content if necessary

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -404,6 +404,28 @@
                                                placeholder="Enter API version">
                                     </div>
                                 </div>
+
+                                <!-- Token Limit Field -->
+                                <div class="space-y-2">
+                                    <label for="tokenLimit">Token Limit</label>
+                                    <input type="number" 
+                                        id="tokenLimit" 
+                                        name="tokenLimit"
+                                        value="<%= config.TOKEN_LIMIT %>"
+                                        class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                        placeholder="Enter token limit of model">
+                                </div>
+
+                                <!--  Response Tokens Field -->
+                                <div class="space-y-2">
+                                    <label for="responseTokens">Response Tokens</label>
+                                    <input type="number" 
+                                        id="responseTokens" 
+                                        name="responseTokens"
+                                        value="<%= config.RESPONSE_TOKENS %>"
+                                        class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                        placeholder="Enter approximate token amount for response">
+                                </div>
                             </div>
                         </section>
         

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -346,6 +346,26 @@
                                                    placeholder="Enter API version">
                                         </div>
                                     </div>
+
+                                    <div class="form-group">
+                                        <label for="tokenLimit">Token Limit</label>
+                                        <input type="number" 
+                                               id="tokenLimit" 
+                                               name="tokenLimit"
+                                               value="<%= config.TOKEN_LIMIT %>"
+                                               class="modern-input"
+                                               placeholder="Enter token limit of model">
+                                    </div>
+                        
+                                    <div class="form-group">
+                                        <label for="responseTokens">Response Tokens</label>
+                                        <input type="number" 
+                                               id="responseTokens" 
+                                               name="responseTokens"
+                                               value="<%= config.RESPONSE_TOKENS %>"
+                                               class="modern-input"
+                                               placeholder="Enter approximate token amount for the response">
+                                    </div>
                                 </div>
                             </section>
                         </div>


### PR DESCRIPTION
There was already a token limitation in place in the code, however it was set to a hardcoded limit of 128000 tokens. So if you have a smaller "budget" of tokens per call, the whole analysis might fail.
This pull request adds a configuration (in the AI setup GUI or via environment variables) for according limits. For example, even my paid Azure OpenAI subscription is limited to 8K tokens per call. This pull also makes the assumption for the size of the response configurable, as it goes into the truncation calculation. The default of 1000 tokens is VERY generous and shrinks the content accordingly (which doesn't matter on the basis of 128k Tokens ;-) ). The response JSON is rather 100 tokens, so you can set  a different value here. 
The defaults will be according to the previous hardcoded settings.