### PR TITLE
Exactly compute the new content size according to given token limit

### DIFF
--- a/services/manualService.js
+++ b/services/manualService.js
@@ -1,3 +1,9 @@
+const { 
+    calculateTokens, 
+    calculateTotalPromptTokens, 
+    truncateToTokenLimit, 
+    writePromptToFile 
+} = require('./serviceUtils');
 const axios = require('axios');
 const OpenAI = require('openai');
 const config = require('../config/config');
@@ -26,27 +32,6 @@ class ManualService {
         }
     }
 
-    async writePromptToFile(systemPrompt, truncatedContent) {
-        const filePath = './logs/prompt.txt';
-        const maxSize = 10 * 1024 * 1024;
-      
-        try {
-          const stats = await fs.stat(filePath);
-          if (stats.size > maxSize) {
-            await fs.unlink(filePath); // Delete the file if is biger 10MB
-          }
-        } catch (error) {
-          if (error.code !== 'ENOENT') {
-            console.warn('[WARNING] Error checking file size:', error);
-          }
-        }
-      
-        try {
-          await fs.appendFile(filePath, systemPrompt + truncatedContent + '\n\n');
-        } catch (error) {
-          console.error('[ERROR] Error writing to file:', error);
-        }
-      }
     
     async analyzeDocument(content, existingTags, provider) {
         try {

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -1,3 +1,9 @@
+const { 
+    calculateTokens, 
+    calculateTotalPromptTokens, 
+    truncateToTokenLimit, 
+    writePromptToFile 
+} = require('./serviceUtils');
 const axios = require('axios');
 const config = require('../config/config');
 const fs = require('fs').promises;
@@ -137,12 +143,12 @@ class OllamaService {
     async analyzePlayground(content, prompt) {
         try {
             // Calculate context window size
-            const promptTokenCount = this._calculatePromptTokenCount(prompt);
+            const promptTokenCount = await calculateTokens(prompt);
             const numCtx = this._calculateNumCtx(promptTokenCount, 1024);
-            
+
             // Generate playground system prompt (simpler than full analysis)
             const systemPrompt = this._generatePlaygroundSystemPrompt();
-            
+
             // Call Ollama API
             const response = await this._callOllamaAPI(
                 prompt + "\n\n" + JSON.stringify(content), 
@@ -536,32 +542,6 @@ class OllamaService {
             + '================================================================================\n\n';
             
         await this._writePromptToFile(content);
-    }
-
-    /**
-     * Write prompt to log file
-     * @param {string} content - Content to write
-     */
-    async _writePromptToFile(content) {
-        const filePath = './logs/prompt.txt';
-        const maxSize = 10 * 1024 * 1024;
-      
-        try {
-            try {
-                const stats = await fs.stat(filePath);
-                if (stats.size > maxSize) {
-                    await fs.unlink(filePath); // Delete the file if is bigger than 10MB
-                }
-            } catch (error) {
-                if (error.code !== 'ENOENT') {
-                    console.warn('[WARNING] Error checking file size:', error);
-                }
-            }
-          
-            await fs.appendFile(filePath, content);
-        } catch (error) {
-            console.error('[ERROR] Error writing to file:', error);
-        }
     }
 }
 

--- a/services/serviceUtils.js
+++ b/services/serviceUtils.js
@@ -1,0 +1,76 @@
+const tiktoken = require('tiktoken');
+const fs = require('fs').promises;
+const path = require('path');
+
+// Calculate tokens for a given text
+async function calculateTokens(text, model = process.env.OPENAI_MODEL || "gpt-4o-mini") {
+    const tokenizer = tiktoken.encoding_for_model(model);
+    return tokenizer.encode(text).length;
+}
+
+// Calculate total tokens for a system prompt and additional prompts
+async function calculateTotalPromptTokens(systemPrompt, additionalPrompts = [], model = process.env.OPENAI_MODEL || "gpt-4o-mini") {
+    let totalTokens = 0;
+
+    // Count tokens for system prompt
+    totalTokens += await calculateTokens(systemPrompt, model);
+
+    // Count tokens for additional prompts
+    for (const prompt of additionalPrompts) {
+        if (prompt) { // Only count if prompt exists
+            totalTokens += await calculateTokens(prompt, model);
+        }
+    }
+
+    // Add tokens for message formatting (approximately 4 tokens per message)
+    const messageCount = 1 + additionalPrompts.filter(p => p).length; // Count system + valid additional prompts
+    totalTokens += messageCount * 4;
+
+    return totalTokens;
+}
+
+// Truncate text to fit within token limit
+async function truncateToTokenLimit(text, maxTokens, model = process.env.OPENAI_MODEL || "gpt-4o-mini") {
+
+    const tokenizer = tiktoken.encoding_for_model(model);
+    const tokens = tokenizer.encode(text);
+  
+    if (tokens.length <= maxTokens) {
+      tokenizer.free();
+      return text;
+    }
+  
+    const truncatedTokens = tokens.slice(0, maxTokens);
+    const truncatedText = tokenizer.decode(truncatedTokens);
+    tokenizer.free();
+    
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(truncatedText);
+}
+
+// Write prompt and content to a file with size management
+async function writePromptToFile(systemPrompt, truncatedContent, filePath = './logs/prompt.txt', maxSize = 10 * 1024 * 1024) {
+    try {
+        const stats = await fs.stat(filePath);
+        if (stats.size > maxSize) {
+            await fs.unlink(filePath); // Delete the file if it exceeds max size
+        }
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.warn('[WARNING] Error checking file size:', error);
+        }
+    }
+
+    try {
+        await fs.appendFile(filePath, systemPrompt + truncatedContent + '\n\n');
+    } catch (error) {
+        console.error('[ERROR] Error writing to file:', error);
+    }
+}
+
+module.exports = {
+    calculateTokens,
+    calculateTotalPromptTokens,
+    truncateToTokenLimit,
+    writePromptToFile
+};


### PR DESCRIPTION
While cutting the content proportionally to the max/actual token ratio ist a quick pragmatical solution, I had some large files where that computation was about 1k tokens off (i.e. way too large) for the final truncated content (depends on the type of content and how much token sizes actually deviates from mean token size). With a low token quota, you easily run into troubles for those large documents.
The exact computation is actually rather simple, as you just have to slice the token result array from the encoder, and then just decode the first part back into the content string. That way you get the exact amount of desired tokens.
To not have to change that in the multiple places where truncation was defined & used, I created a serviceUtils.js file and refactored the truncation (and some other redundant fcts.) into this single source for better maintainability.