### PR TITLE
 Refactor Azure OpenAI Initialization and Model Handling

### DIFF
--- a/services/azureService.js
+++ b/services/azureService.js
@@ -165,7 +165,7 @@ class AzureOpenAIService {
       await this.writePromptToFile(systemPrompt, truncatedContent);
 
       const response = await this.client.chat.completions.create({
-        model: "", //no model has to be set in azure openai when deplyoment is set on init
+        model: config.azure.deploymentName, //no model has to be set in azure openai when deplyoment is set on init
         messages: [
           {
             role: "system",
@@ -286,7 +286,7 @@ class AzureOpenAIService {
       
       // Make API request
       const response = await this.client.chat.completions.create({
-        model: "", //no model has to be set in azure openai when deplyoment is set on init
+        model: config.azure.deploymentName, //no model has to be set in azure openai when deplyoment is set on init
         messages: [
           {
             role: "system",

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -165,7 +165,7 @@ class AzureOpenAIService {
       await this.writePromptToFile(systemPrompt, truncatedContent);
 
       const response = await this.client.chat.completions.create({
-        model: config.azure.deploymentName, //no model has to be set in azure openai when deplyoment is set on init
+        model: config.azure.deploymentName, //azure openai uses deployment name as model parameter
         messages: [
           {
             role: "system",
@@ -286,7 +286,7 @@ class AzureOpenAIService {
       
       // Make API request
       const response = await this.client.chat.completions.create({
-        model: config.azure.deploymentName, //no model has to be set in azure openai when deplyoment is set on init
+        model: config.azure.deploymentName, //azure openai uses deployment name as model parameter
         messages: [
           {
             role: "system",

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -13,23 +13,7 @@ class AzureOpenAIService {
   }
 
   initialize() {
-    if (!this.client && config.aiProvider === 'ollama') {
-      this.client = new OpenAI({
-        baseURL: config.ollama.apiUrl + '/v1',
-        apiKey: 'ollama'
-      });
-    } else if (!this.client && config.aiProvider === 'custom') {
-      this.client = new OpenAI({
-        baseURL: config.custom.apiUrl,
-        apiKey: config.custom.apiKey
-      });
-    } else if (!this.client && config.aiProvider === 'openai') {
-    if (!this.client && config.openai.apiKey) {
-      this.client = new OpenAI({
-        apiKey: config.openai.apiKey
-      });
-    }
-    } else if (!this.client && config.aiProvider === 'azure') {
+    if (!this.client && config.aiProvider === 'azure') {
       this.client = new AzureOpenAI({
         apiKey: config.azure.apiKey,
         endpoint: config.azure.endpoint,
@@ -181,7 +165,7 @@ class AzureOpenAIService {
       await this.writePromptToFile(systemPrompt, truncatedContent);
 
       const response = await this.client.chat.completions.create({
-        model: model,
+        model: "", //no model has to be set in azure openai when deplyoment is set on init
         messages: [
           {
             role: "system",
@@ -302,7 +286,7 @@ class AzureOpenAIService {
       
       // Make API request
       const response = await this.client.chat.completions.create({
-        model: process.env.OPENAI_MODEL,
+        model: "", //no model has to be set in azure openai when deplyoment is set on init
         messages: [
           {
             role: "system",

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -135,7 +135,7 @@ class SetupService {
                 deploymentName: deploymentName,
                 apiVersion: apiVersion });
         const response = await openai.chat.completions.create({
-          model: "gpt-4o-mini",
+          model: "", //no model has to be set on azure openai when the deployment is set on init
           messages: [{ role: "user", content: "Test" }],
         });
         const now = new Date();

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -135,7 +135,7 @@ class SetupService {
                 deploymentName: deploymentName,
                 apiVersion: apiVersion });
         const response = await openai.chat.completions.create({
-          model: "", //no model has to be set on azure openai when the deployment is set on init
+          model: deploymentName, //no model has to be set on azure openai when the deployment is set on init
           messages: [{ role: "user", content: "Test" }],
         });
         const now = new Date();

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -135,7 +135,7 @@ class SetupService {
                 deploymentName: deploymentName,
                 apiVersion: apiVersion });
         const response = await openai.chat.completions.create({
-          model: deploymentName, //no model has to be set on azure openai when the deployment is set on init
+          model: deploymentName, //azure openai uses deployment name as model parameter
           messages: [{ role: "user", content: "Test" }],
         });
         const now = new Date();


### PR DESCRIPTION
This PR refactors the Azure OpenAI integration and **allows other models than gpt-4o-mini** (e.g. gpt-4.1-nano).

Key improvements include:

- Simplified client initialization: Removed redundant provider checks and streamlined logic to initialize the Azure OpenAI client only when config.aiProvider === 'azure'.

-  **Corrected model usage**: Replaced hardcoded model names with config.azure.deploymentName in all chat.completions.create calls, as Azure uses deployment names instead of model names at runtime.

-  Code cleanup: Removed unused or outdated initialization blocks for other providers (ollama, custom, etc.) within the Azure service context.
