### PR TITLE
Fix JSON parsing bug in manualService

### DIFF
--- a/services/manualService.js
+++ b/services/manualService.js
@@ -77,8 +77,8 @@ class ManualService {
     
         let jsonContent = response.choices[0].message.content;
         jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-        
-        const parsedResponse = JSON.parse(jsonContent);
+
+        let parsedResponse;
         try {
             parsedResponse = JSON.parse(jsonContent);
             fs.appendFile('./logs/response.txt', jsonContent, (err) => {
@@ -125,8 +125,8 @@ class ManualService {
     
         let jsonContent = response.choices[0].message.content;
         jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-        
-        const parsedResponse = JSON.parse(jsonContent);
+
+        let parsedResponse;
         try {
             parsedResponse = JSON.parse(jsonContent);
             fs.appendFile('./logs/response.txt', jsonContent, (err) => {


### PR DESCRIPTION
## Summary
- avoid reassigning const when parsing JSON in manualService

## Testing
- `npm test` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486b02f3a0832e9ee895e4a18b83d2