### PR TITLE
fix: truncate long titles to 128 characters.

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1226,6 +1226,12 @@ async getOrCreateDocumentType(name) {
       //   }
       // }
       
+      // Validate title length before sending to API
+      if (updateData.title && updateData.title.length > 128) {
+        updateData.title = updateData.title.substring(0, 127) + '…';
+        console.log(`[WARN] Title truncated to 128 characters for document ${documentId}`);
+      }
+      
       console.log('[DEBUG] Final update data:', updateData);
       await this.client.patch(`/documents/${documentId}/`, updateData);
       console.log(`[SUCCESS] Updated document ${documentId} with:`, updateData);


### PR DESCRIPTION
Hi,

i have a document which generates a really long title when processing through paperless-ai. After looking at the database schema in paperless-ngx it shows that the title is limited to 128 characters.

This PR will check the size of the title and adds a `…` at the end of the title to stay within the limit