### PR TITLE
Implement setting to create objects without owner

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -65,7 +65,8 @@ module.exports = {
   externalApiConfig: externalApiConfig,
   paperless: {
     apiUrl: process.env.PAPERLESS_API_URL,
-    apiToken: process.env.PAPERLESS_API_TOKEN
+    apiToken: process.env.PAPERLESS_API_TOKEN,
+    setObjectOwner: process.env.PAPERLESS_SET_OBJECT_OWNER === 'yes'
   },
   openai: {
     apiKey: process.env.OPENAI_API_KEY

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3971,6 +3971,7 @@ router.post('/settings', express.json(), async (req, res) => {
     const { 
       paperlessUrl, 
       paperlessToken,
+      paperlessSetObjectOwner,
       aiProvider,
       openaiKey,
       openaiModel,
@@ -4014,6 +4015,7 @@ router.post('/settings', express.json(), async (req, res) => {
       PAPERLESS_API_URL: process.env.PAPERLESS_API_URL || '',
       PAPERLESS_API_TOKEN: process.env.PAPERLESS_API_TOKEN || '',
       PAPERLESS_USERNAME: process.env.PAPERLESS_USERNAME || '',
+      PAPERLESS_SET_OBJECT_OWNER: process.env.PAPERLESS_SET_OBJECT_OWNER || 'no',
       AI_PROVIDER: process.env.AI_PROVIDER || '',
       OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
       OPENAI_MODEL: process.env.OPENAI_MODEL || '',
@@ -4118,6 +4120,7 @@ router.post('/settings', express.json(), async (req, res) => {
     if (paperlessUrl) updatedConfig.PAPERLESS_API_URL = paperlessUrl + '/api';
     if (paperlessToken) updatedConfig.PAPERLESS_API_TOKEN = paperlessToken;
     if (paperlessUsername) updatedConfig.PAPERLESS_USERNAME = paperlessUsername;
+    updatedConfig.PAPERLESS_SET_OBJECT_OWNER = paperlessSetObjectOwner? 'yes':'no';
 
     // Handle AI provider configuration
     if (aiProvider) {

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -222,7 +222,10 @@ class PaperlessService {
     
     try {
       // Versuche zuerst, den Tag zu erstellen
-      const response = await this.client.post('/tags/', { name: tagName });
+      const response = await this.client.post('/tags/', { 
+        name: tagName,
+        ...(config.paperless.setObjectOwner ? { owner: null } : {})
+      });
       const newTag = response.data;
       console.log(`[DEBUG] Successfully created tag "${tagName}" with ID ${newTag.id}`);
       this.tagCache.set(normalizedName, newTag);
@@ -945,7 +948,8 @@ async searchForExistingCorrespondent(correspondent) {
         // Create new correspondent only if restrictions are not enabled
         try {
             const createResponse = await this.client.post('/correspondents/', { 
-                name: name 
+                name: name ,
+                ...(config.paperless.setObjectOwner ? { owner: null } : {})
             });
             console.log(`[DEBUG] Created new correspondent "${name}" with ID ${createResponse.data.id}`);
             return createResponse.data;

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -254,7 +254,24 @@
                                            class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                            placeholder="Your Paperless-ngx username"
                                            required>
-                                </div>                                
+                                </div>
+
+                                <div class="border border-gray-200 shadow-sm rounded-lg hover:border-blue-500 transition-colors duration-200 mb-4">
+                                    <label for="paperlessSetObjectOwner" class="flex items-center p-4 cursor-pointer w-full">
+                                        <input type="checkbox" 
+                                            id="paperlessSetObjectOwner" 
+                                            name="paperlessSetObjectOwner" 
+                                            class="w-5 h-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                                            <%= config.PAPERLESS_SET_OBJECT_OWNER === 'yes' ? 'checked' : '' %>>
+                                        <div class="ml-3">
+                                            <div class="flex items-center text-gray-900 font-medium">
+                                                <i class="fas fa-lock-open mr-2 text-blue-500"></i>
+                                                Create Objects without Owner
+                                            </div>
+                                            <p class="text-sm text-gray-500 mt-1">Paperless-AI will create tags and correspondents with no owner, rather than with its own username</p>
+                                        </div>
+                                    </label>
+                                </div>
                             </div>
                         </section>
         


### PR DESCRIPTION
This implements a minimal workaround for #602 and #583.
It adds a setting to make Paperless-AI create its objects (tags and correspondents) without an owner, so every paperless user can see them.