### PR TITLE
fix: Add an event listener to the submit button

### DIFF
--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -218,6 +218,10 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 });
 
+document.getElementById('messageForm').querySelector('.send-button').addEventListener('click', async (e) => {
+    await submitForm();
+})
+
 document.getElementById('messageInput').addEventListener('keydown', async (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();


### PR DESCRIPTION
Fixes #499.
As far as I can tell, the submit button never got an event listener assigned to it.