### PR TITLE
Fix: Automatic scan tag serialization issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -362,10 +362,13 @@ async function scanInitial() {
     ]);
     //get existing correspondent list
     existingCorrespondentList = existingCorrespondentList.map(correspondent => correspondent.name);
+    
+    // Extract tag names from tag objects
+    const existingTagNames = existingTags.map(tag => tag.name);
 
     for (const doc of documents) {
       try {
-        const result = await processDocument(doc, existingTags, existingCorrespondentList, ownUserId);
+        const result = await processDocument(doc, existingTagNames, existingCorrespondentList, ownUserId);
         if (!result) continue;
 
         const { analysis, originalData } = result;
@@ -397,10 +400,13 @@ async function scanDocuments() {
 
     //get existing correspondent list
     existingCorrespondentList = existingCorrespondentList.map(correspondent => correspondent.name);
+    
+    // Extract tag names from tag objects
+    const existingTagNames = existingTags.map(tag => tag.name);
 
     for (const doc of documents) {
       try {
-        const result = await processDocument(doc, existingTags, existingCorrespondentList, ownUserId);
+        const result = await processDocument(doc, existingTagNames, existingCorrespondentList, ownUserId);
         if (!result) continue;
 
         const { analysis, originalData } = result;


### PR DESCRIPTION
## Summary
- Fixed automatic scan passing tag objects instead of tag names to AI prompts
- Automatic scans now properly extract tag names like manual scans do

## Fixes #600

## Problem
The automatic scan feature was passing full tag objects to the AI service, which resulted in tags appearing as '[object Object]' in the system prompt. Manual scans correctly extracted tag names before passing them to the AI.

## Solution
Modified both scanInitial() and scanDocuments() functions in server.js to:
1. Extract tag names from the tag objects returned by getTags()
2. Pass the extracted tag names array to processDocument() instead of the full tag objects

This ensures automatic scans behave the same as manual scans when building the AI prompt.

## Testing
- The fix ensures existing tags are properly serialized as comma-separated names
- Both automatic and manual scans now use the same format for tags
- No changes to the AI analysis logic were needed