### PR TITLE
Add support for openai o3 model

### DIFF
--- a/services/manualService.js
+++ b/services/manualService.js
@@ -72,7 +72,7 @@ class ManualService {
                 content: content
             }
             ],
-            ...(model !== 'o3-mini' && { temperature: 0.3 }),
+            ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
         });
     
         let jsonContent = response.choices[0].message.content;
@@ -168,7 +168,7 @@ class ManualService {
                     content: content
                 }
                 ],
-                ...(model !== 'o3-mini' && { temperature: 0.3 }),
+                ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
             });
         
             let jsonContent = response.choices[0].message.content;

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -186,7 +186,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
       });
 
       if (!response?.choices?.[0]?.message?.content) {
@@ -310,7 +310,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
       });
 
       // Handle response

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -301,6 +301,7 @@
                                             <option value="gpt-3.5-turbo-0125" <%= config.OPENAI_MODEL === 'gpt-3.5-turbo-0125' ? 'selected' : '' %>>GPT-3.5 Turbo</option>
                                             <option value="gpt-4o" <%= config.OPENAI_MODEL === 'gpt-4o' ? 'selected' : '' %>>GPT-4o</option>
                                             <option value="o3-mini" <%= config.OPENAI_MODEL === 'o3-mini' ? 'selected' : '' %>>o3-mini</option>
+                                            <option value="o3" <%= config.OPENAI_MODEL === 'o3' ? 'selected' : '' %>>o3</option>
                                             <option value="gpt-4o-mini" <%= config.OPENAI_MODEL === 'gpt-4o-mini' ? 'selected' : '' %>>GPT-4o-mini (Best value)</option>
                                         </select>
                                     </div>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -236,6 +236,7 @@
                                                 <option value="gpt-3.5-turbo-0125" <%= config.OPENAI_MODEL === 'gpt-3.5-turbo-0125' ? 'selected' : '' %>>GPT-3.5 Turbo</option>
                                                 <option value="gpt-4o" <%= config.OPENAI_MODEL === 'gpt-4o' ? 'selected' : '' %>>GPT-4o</option>
                                                 <option value="o3-mini" <%= config.OPENAI_MODEL === 'o3-mini' ? 'selected' : '' %>>o3-mini</option>
+                                                <option value="o3" <%= config.OPENAI_MODEL === 'o3' ? 'selected' : '' %>>o3</option>
                                                 <option value="gpt-4o-mini" <%= config.OPENAI_MODEL === 'gpt-4o-mini' ? 'selected' : '' %>>GPT-4o-mini (Best value)</option>
                                             </select>
                                         </div>


### PR DESCRIPTION
The o3 model is now cheaper than the 4o model in imho more powerful. It is slower but that is not an issue, I can wait a few more seconds for my document to be processed.

As requested in issue #614 