### PR TITLE
Fix: Normalize Paperless API URL to prevent double slashes

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3632,8 +3632,9 @@ router.post('/setup', express.json(), async (req, res) => {
     console.log('Setup request received:', redactedBody);
 
 
-    // Initialize paperlessService with the new credentials
-    const paperlessApiUrl = paperlessUrl + '/api';
+    // Normalize URL by removing trailing slash, then initialize paperlessService
+    const normalizedUrl = paperlessUrl.replace(/\/$/, '');
+    const paperlessApiUrl = normalizedUrl + '/api';
     const initSuccess = await paperlessService.initializeWithCredentials(paperlessApiUrl, paperlessToken);
     
     if (!initSuccess) {
@@ -4141,7 +4142,10 @@ router.post('/settings', express.json(), async (req, res) => {
 
     const updatedConfig = {};
 
-    if (paperlessUrl) updatedConfig.PAPERLESS_API_URL = paperlessUrl + '/api';
+    if (paperlessUrl) {
+      const normalizedUrl = paperlessUrl.replace(/\/$/, '');
+      updatedConfig.PAPERLESS_API_URL = normalizedUrl + '/api';
+    }
     if (paperlessToken) updatedConfig.PAPERLESS_API_TOKEN = paperlessToken;
     if (paperlessUsername) updatedConfig.PAPERLESS_USERNAME = paperlessUsername;
 

--- a/urlUtils.js
+++ b/urlUtils.js
@@ -1,0 +1,11 @@
+/**
+ * Normalizes a URL by removing any trailing slashes.
+ * @param {string} url The URL to normalize.
+ * @returns {string} The normalized URL, or an empty string if the input is invalid.
+ */
+function normalizeUrl(url) {
+  if (typeof url !== 'string' || !url) return '';
+  return url.replace(/\/$/, '');
+}
+
+module.exports = { normalizeUrl };


### PR DESCRIPTION
When configuring the Paperless-ngx connection, users might enter the URL with a trailing slash (e.g., `http://paperless.host/`).

The previous implementation would append `/api` directly, resulting in an incorrect URL with double slashes (`http://paperless.host//api`). This could lead to connection failures or unexpected behavior with the Paperless-ngx API.

This commit resolves the issue by normalizing the input URL. It removes any trailing slash before concatenating the `/api` path. This ensures that the final API URL is always correctly formatted, regardless of the user's input.

The normalization has been applied in two key places:
- The initial application setup (`POST /setup`)
- The application settings update (`POST /settings`)