### PR TITLE
fix: run `processQueue` in background to not delay webhook response

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -2511,9 +2511,9 @@ router.post('/api/webhook/document', async (req, res) => {
       if (prompt) {
         usePrompt = true;
         console.log('[DEBUG] Using custom prompt:', prompt);
-        await processQueue(prompt);
+        processQueue(prompt).then();
       } else {
-        await processQueue();
+        processQueue().then();
       }
       
       


### PR DESCRIPTION
I reviewed `processQueue` and it can be time-consuming, depending on the amount of data being loaded from PaperlessNGX. For the response, it's outcome doesn't matter. So instead of letting the webhook response wait until document queue is cleaned, I'd suggest to run it async in background.