### PR TITLE
Add GPT-5 model options and tune temps

### DIFF
--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -187,7 +187,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model && model.toLowerCase().includes('gpt-5') ? { temperature: 1 } : (model !== 'o3-mini' ? { temperature: 0.3 } : {})),
       });
 
       if (!response?.choices?.[0]?.message?.content) {
@@ -311,7 +311,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model && model.toLowerCase().includes('gpt-5') ? { temperature: 1 } : (model !== 'o3-mini' ? { temperature: 0.3 } : {})),
       });
 
       // Handle response

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -233,7 +233,9 @@
                                             <select id="openaiModel" 
                                                     name="openaiModel"
                                                     class="modern-input">
-                                                <option value="gpt-3.5-turbo-0125" <%= config.OPENAI_MODEL === 'gpt-3.5-turbo-0125' ? 'selected' : '' %>>GPT-3.5 Turbo</option>
+                                                <option value="gpt-5-mini" <%= config.OPENAI_MODEL === 'gpt-5-mini' ? 'selected' : '' %>>GPT-5-mini</option>
+                                                <option value="gpt-5-nano" <%= config.OPENAI_MODEL === 'gpt-5-nano' ? 'selected' : '' %>>GPT-5-nano</option>
+                                                <option value="gpt-5" <%= config.OPENAI_MODEL === 'gpt-5' ? 'selected' : '' %>>GPT-5</option>
                                                 <option value="gpt-4o" <%= config.OPENAI_MODEL === 'gpt-4o' ? 'selected' : '' %>>GPT-4o</option>
                                                 <option value="o3-mini" <%= config.OPENAI_MODEL === 'o3-mini' ? 'selected' : '' %>>o3-mini</option>
                                                 <option value="gpt-4o-mini" <%= config.OPENAI_MODEL === 'gpt-4o-mini' ? 'selected' : '' %>>GPT-4o-mini (Best value)</option>


### PR DESCRIPTION
- Setup UI: add GPT-5, GPT-5-mini, and GPT-5-nano options; remove GPT-3.5
- OpenAI service: set temperature=1 for GPT-5 models; keep 0.3 for others (except o3-mini, which remains default). Improves creativity on GPT-5