### PR TITLE
Fix crash in rag view when statusData.ai_model is null

### DIFF
--- a/views/rag.ejs
+++ b/views/rag.ejs
@@ -912,7 +912,7 @@
 
         function updateStatus(statusData) {
             // Update AI model info
-            if (statusData.ai_status === 'ok') {
+            if (statusData.ai_status === 'ok' && statusData.ai_model) {
                 const modelName = statusData.ai_model.toUpperCase();
                 aiModelName.textContent = `AI MODEL: ${modelName}`;
             } else {


### PR DESCRIPTION
Hi clusterzx,
is this how #697 should be solved? Or should there never be a null in the first place?
Another option might be to skip updating the AI model in the view, when the status doesn't return anything
cheers!