### PR TITLE
handle models which embed thinking tags

### DIFF
--- a/services/customService.js
+++ b/services/customService.js
@@ -212,6 +212,7 @@ class CustomOpenAIService {
       };
 
       let jsonContent = response.choices[0].message.content;
+      jsonContent = jsonContent.replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>/gi, '');
       jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
 
       let parsedResponse;
@@ -339,6 +340,7 @@ class CustomOpenAIService {
       };
 
       let jsonContent = response.choices[0].message.content;
+      jsonContent = jsonContent.replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>/gi, '');
       jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
 
       let parsedResponse;


### PR DESCRIPTION
I'm using `gpt-oss`, which, even when used with `/no_thinking`, still adds an empty <think> tag. This causes JSON creation to fail. Let's filter out the tag, since it's not useful for paperless-ai.