### PR TITLE
take prompt + content for token calculation in playground

### DIFF
--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -184,7 +184,7 @@ class OllamaService {
     async analyzePlayground(content, prompt) {
         try {
             // Calculate context window size
-            const promptTokenCount = await calculateTokens(prompt);
+            const promptTokenCount = await calculateTokens(prompt + "\n\n" + content);
             const numCtx = this._calculateNumCtx(promptTokenCount, 1024);
 
             // Generate playground system prompt (simpler than full analysis)


### PR DESCRIPTION
Fixes https://github.com/clusterzx/paperless-ai/issues/745

Changed calculation of tokens in analyzePlayground. It now contains the prompt and the context