### PR TITLE
Make the titles in RAG Sources clickable links to Paperless

### DIFF
--- a/services/ragService.js
+++ b/services/ragService.js
@@ -7,6 +7,7 @@ const paperlessService = require('./paperlessService');
 class RagService {
   constructor() {
     this.baseUrl = process.env.RAG_SERVICE_URL || 'http://localhost:8000';
+    this.paperlessBaseUrl = process.env.PAPERLESS_BASE_URL || 'http://localhost:8080';
   }
 
   /**
@@ -117,9 +118,15 @@ class RagService {
         answer = "An error occurred while generating an answer. Please try again later.";
       }
       
+      // 4. Modify sources to include the link to the original Paperless document
+      const sourcesWithLinks = sources.map(source => ({
+        ...source,
+        link: source.doc_id ? `${this.paperlessBaseUrl}/documents/${source.doc_id}/` : null
+      }));
+
       return {
         answer,
-        sources
+        sources:sourcesWithLinks
       };
     } catch (error) {
       console.error('Error in askQuestion:', error);

--- a/views/rag.ejs
+++ b/views/rag.ejs
@@ -244,6 +244,12 @@
             margin-bottom: 0.25rem;
         }
 
+        .source-title .source-link {
+            color: green; /* Simple link color */
+            text-decoration: underline; /* Standard underline */
+            font-weight: bold;
+        }
+
         .source-meta {
             display: flex;
             justify-content: space-between;
@@ -1148,10 +1154,13 @@
                 sources.forEach((source, index) => {
                     const date = source.date ? new Date(source.date).toLocaleDateString('en-US') : 'Unknown';
                     const hidden = index > 0 ? ' hidden' : '';
-                    
+                    const titleContent = source.link 
+                        ? `<a href="${source.link}" target="_blank" class="source-link">${source.title || 'Unknown Title'}</a>` 
+                        : (source.title || 'Unknown Title');
+
                     html += `
                         <div class="source${hidden}" data-index="${index}">
-                            <div class="source-title">${source.title || 'Unknown Title'}</div>
+                            <div class="source-title">${titleContent}</div>
                             <p>${source.snippet || 'No excerpt available'}</p>
                             <div class="source-meta">
                                 <span>${source.correspondent || 'Unknown Sender'}</span>


### PR DESCRIPTION
Makes the sources that are returned in RAG chat clickable links to the Paperless document.
Defines environment variable PAPERLESS_BASE_URL to create the links