### PR TITLE
Determine # of RAG sources by env variable

### DIFF
--- a/services/ragService.js
+++ b/services/ragService.js
@@ -55,10 +55,13 @@ class RagService {
    */
   async askQuestion(question) {
     try {
+      // Determine the maximum number of sources to use from environment variable, default to 5
+      const maxSources = parseInt(process.env.RAG_SOURCES, 10) || 5;
+      
       // 1. Get context from the RAG service
       const response = await axios.post(`${this.baseUrl}/context`, { 
         question,
-        max_sources: 5
+        max_sources: maxSources
       });
       
       const { context, sources } = response.data;


### PR DESCRIPTION
Defines env variable RAG_SOURCES to determine how many RAG sources are returned. Default is 5 (same as existing code).

Note: too many sources may overwhelm some smaller models. You may want to reduce the sources to less than 5 for smaller models.

This pull request addresses suggestions like #694 