### PR TITLE
Fix API 400 errors: truncate custom field strings and preserve required fields in PATCH

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1213,17 +1213,19 @@ async getOrCreateDocumentType(name) {
         console.log(`[DEBUG] Combined tags:`, combinedTags);
       }
 
-      // Always include correspondent in the PATCH payload to satisfy required field validation
-      if (currentDoc.correspondent && updates.correspondent) {
-        console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
-        updates.correspondent = currentDoc.correspondent;
-      } else if (currentDoc.correspondent && !updates.correspondent) {
-        console.log('[DEBUG] Preserving existing correspondent in PATCH payload:', currentDoc.correspondent);
+      // Always preserve existing correspondent to satisfy required field validation
+      // This maintains backward compatibility where existing correspondents are not overwritten
+      if (currentDoc.correspondent) {
+        if (updates.correspondent) {
+          console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
+        } else {
+          console.log('[DEBUG] Preserving existing correspondent in PATCH payload:', currentDoc.correspondent);
+        }
         updates.correspondent = currentDoc.correspondent;
       }
 
       // Always include storage_path in the PATCH payload to satisfy required field validation
-      if (currentDoc.storage_path !== undefined && currentDoc.storage_path !== null && !updates.storage_path) {
+      if (currentDoc.storage_path && !updates.storage_path) {
         console.log('[DEBUG] Preserving existing storage_path in PATCH payload:', currentDoc.storage_path);
         updates.storage_path = currentDoc.storage_path;
       }


### PR DESCRIPTION
Trying to fix: [#759
](https://github.com/clusterzx/paperless-ai/issues/759)

This pull request makes important updates to the `paperlessService.js` service to improve data integrity and ensure compatibility with required field validations. The main changes include always preserving certain required fields during document updates and enforcing maximum length constraints on custom field values.

**Required field handling:**

* Always preserve the existing `correspondent` field in the PATCH payload to avoid overwriting and to satisfy required field validation. This ensures backward compatibility and prevents accidental removal of required data.
* Always include the existing `storage_path` in the PATCH payload if not present in the update, maintaining required field validation.

**Custom field validation:**

* Enforce a maximum length of 128 characters for string values in `custom_fields` by truncating any values that exceed this limit before sending updates to the API. This replaces the previous (commented-out) logic for deleting or clearing custom fields.