### PR TITLE
Security: Mask API key in Custom AI config logging

### DIFF
--- a/services/setupService.js
+++ b/services/setupService.js
@@ -93,10 +93,19 @@ class SetupService {
       apiKey: apiKey,
       model: model
     };
-    console.log('Custom AI config:', config);
+    const safeConfig = {
+      baseURL: config.baseURL,
+      apiKey: config.apiKey
+        ? (config.apiKey.length > 8
+          ? `${config.apiKey.substring(0, 4)}...${config.apiKey.substring(config.apiKey.length - 4)}`
+          : '***')
+        : 'not set',
+      model: config.model
+    };
+    console.log('Custom AI config:', safeConfig);
     try {
-      const openai = new OpenAI({ 
-        apiKey: config.apiKey, 
+      const openai = new OpenAI({
+        apiKey: config.apiKey,
         baseURL: config.baseURL,
       });
       const completion = await openai.chat.completions.create({
@@ -158,7 +167,7 @@ class SetupService {
       paperlessApiUrl,
       config.PAPERLESS_API_TOKEN
     );
-    
+
     if (!paperlessValid) {
       throw new Error('Invalid Paperless configuration');
     }
@@ -167,7 +176,7 @@ class SetupService {
     const aiProvider = config.AI_PROVIDER || 'openai';
 
     console.log('AI provider:', aiProvider);
-    
+
     if (aiProvider === 'openai') {
       const openaiValid = await this.validateOpenAIConfig(config.OPENAI_API_KEY);
       if (!openaiValid) {
@@ -213,7 +222,7 @@ class SetupService {
 
       const JSON_STANDARD_PROMPT = `
         Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.:
-        
+
         {
           "title": "xxxxx",
           "correspondent": "xxxxxxxx",
@@ -236,7 +245,7 @@ class SetupService {
         .join('\n');
 
       await fs.writeFile(this.envPath, envContent);
-      
+
       // Reload environment variables
       Object.entries(config).forEach(([key, value]) => {
         process.env[key] = value;


### PR DESCRIPTION
## Summary
Prevents sensitive API keys from being exposed in console logs by masking the API key value in the `validateCustomConfig` method.

## Changes
- Modified `validateCustomConfig` in `services/setupService.js` to create a safe config object for logging
- API keys are now masked when logged:
  - Keys longer than 8 characters: shows first 4 and last 4 characters with "..." in between
  - Shorter keys: shows "***"
  - Missing keys: shows "not set"

## Security Impact
This change prevents API keys from being exposed in application logs, reducing the risk of credential leakage.

## Testing
- Verified that the actual API key is still used correctly for validation
- Confirmed that logs now show masked values instead of plain text keys