### PR TITLE
Fix TypeError for non-string custom field values

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1675,21 +1675,34 @@ async function buildUpdateData(analysis, doc) {
 
     // First, add any new/updated fields
     for (const key in customFields) {
+      if (!Object.hasOwn(customFields, key)) continue;
+
       const customField = customFields[key];
-      
-      if (!customField.field_name || !customField.value?.trim()) {
+
+      if (!customField.field_name || customField.value === null || customField.value === undefined) {
         console.log(`[DEBUG] Skipping empty/invalid custom field`);
         continue;
       }
 
       const fieldDetails = await paperlessService.findExistingCustomField(customField.field_name);
-      if (fieldDetails?.id) {
-        processedFields.push({
-          field: fieldDetails.id,
-          value: customField.value.trim()
-        });
-        processedFieldIds.add(fieldDetails.id);
+      if (!fieldDetails?.id) {
+        continue;
       }
+
+      const finalValue = typeof customField.value === 'string'
+        ? customField.value.trim()
+        : customField.value;
+
+      // Empty strings are skipped, but falsy values (0, false) are preserved
+      if (finalValue === '') {
+        continue;
+      }
+
+      processedFields.push({
+        field: fieldDetails.id,
+        value: finalValue
+      });
+      processedFieldIds.add(fieldDetails.id);
     }
 
     // Then add any existing fields that weren't updated

--- a/server.js
+++ b/server.js
@@ -279,21 +279,34 @@ async function buildUpdateData(analysis, doc) {
 
     // First, add any new/updated fields
     for (const key in customFields) {
+      if (!Object.hasOwn(customFields, key)) continue;
+
       const customField = customFields[key];
-      
-      if (!customField.field_name || !customField.value?.trim()) {
+
+      if (!customField.field_name || customField.value === null || customField.value === undefined) {
         console.log(`[DEBUG] Skipping empty/invalid custom field`);
         continue;
       }
 
       const fieldDetails = await paperlessService.findExistingCustomField(customField.field_name);
-      if (fieldDetails?.id) {
-        processedFields.push({
-          field: fieldDetails.id,
-          value: customField.value.trim()
-        });
-        processedFieldIds.add(fieldDetails.id);
+      if (!fieldDetails?.id) {
+        continue;
       }
+
+      const finalValue = typeof customField.value === 'string'
+        ? customField.value.trim()
+        : customField.value;
+
+      // Empty strings are skipped, but falsy values (0, false) are preserved
+      if (finalValue === '') {
+        continue;
+      }
+
+      processedFields.push({
+        field: fieldDetails.id,
+        value: finalValue
+      });
+      processedFieldIds.add(fieldDetails.id);
     }
 
     // Then add any existing fields that weren't updated


### PR DESCRIPTION
## Summary

- Fix TypeError when AI providers (Mistral, Ollama, etc.) return non-string custom field values (boolean, integer, float)
- Add `Object.hasOwn()` check to prevent prototype pollution
- Preserve falsy values like `0` and `false` while still skipping empty strings

## Problem

The previous code called `.trim()` unconditionally on custom field values:

```javascript
if (!customField.field_name || !customField.value?.trim()) {
  // ...
}
value: customField.value.trim()
```

This caused a `TypeError` when AI providers returned non-string values like:
- `boolean` (true/false) for checkbox fields
- `integer` (42) for number fields  
- `float` (12.34) for decimal fields

## Solution

```javascript
const finalValue = typeof customField.value === 'string'
  ? customField.value.trim()
  : customField.value;
```

- Only call `.trim()` on string values
- Preserve non-string values (boolean, integer, float, arrays) as-is
- Explicit `null`/`undefined` checks instead of relying on optional chaining
- Empty strings are still skipped, but falsy values (`0`, `false`) are preserved

## Affected Files

- `server.js` (buildUpdateData function, lines 280-310)
- `routes/setup.js` (buildUpdateData function, lines 1676-1706)

## Test Plan

- [ ] Verify string custom fields still work correctly (trimmed)
- [ ] Verify empty strings are skipped
- [ ] Verify boolean custom fields (`true`/`false`) are processed correctly
- [ ] Verify integer custom fields (`0`, `42`) are processed correctly
- [ ] Verify float custom fields (`12.34`) are processed correctly
- [ ] Test with different AI providers (OpenAI, Ollama, Mistral, Azure)