### PR TITLE
[Bugfix] Append existing data to system prompt clusterzx#766 clusterz…

### DIFF
--- a/services/azureService.js
+++ b/services/azureService.js
@@ -103,7 +103,7 @@ class AzureOpenAIService {
         .join('\n');
 
       // Get system prompt and model
-      if (config.useExistingData === 'yes' && config.restrictToExistingTags === 'no' && config.restrictToExistingCorrespondents === 'no') {
+      if (config.useExistingData === 'yes') {
         systemPrompt = `
         Pre-existing tags: ${existingTagsList}\n\n
         Pre-existing correspondents: ${existingCorrespondentList}\n\n

--- a/services/customService.js
+++ b/services/customService.js
@@ -102,7 +102,7 @@ class CustomOpenAIService {
         .join('\n');
 
       // Get system prompt based on configuration
-      if (config.useExistingData === 'yes' && config.restrictToExistingTags === 'no' && config.restrictToExistingCorrespondents === 'no') {
+      if (config.useExistingData === 'yes') {
         systemPrompt = `
         Pre-existing tags: ${existingTagsList}\n\n
         Pre-existing correspondents: ${existingCorrespondentList}\n\n

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -286,7 +286,7 @@ class OllamaService {
             .join('\n');
 
         // Get system prompt based on configuration
-        if (config.useExistingData === 'yes' && config.restrictToExistingTags === 'no' && config.restrictToExistingCorrespondents === 'no') {
+        if (config.useExistingData === 'yes') {
             // Format existing tags
             const existingTagsList = existingTags.join(', ');
 

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -112,7 +112,7 @@ class OpenAIService {
         .join('\n');
 
       // Get system prompt and model
-      if (config.useExistingData === 'yes' && config.restrictToExistingTags === 'no' && config.restrictToExistingCorrespondents === 'no') {
+      if (config.useExistingData === 'yes') {
         systemPrompt = `
         Pre-existing tags: ${existingTagsList}\n\n
         Pre-existing correspondents: ${existingCorrespondentList}\n\n


### PR DESCRIPTION
When configuring Paperless-AI to use existing data and not to add Tags and Correspondents, Systemprompt is not extended with the existing data.

This should fix #799 and #766