### PR TITLE
Fix p.275 and p.408 services/ollamaService

### DIFF
--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -272,7 +272,8 @@ class OllamaService {
         // Generate custom fields template for the prompt
         const customFieldsTemplate = {};
 
-        customFieldsObj.custom_fields.forEach((field, index) => {
+        //customFieldsObj.custom_fields.forEach((field, index) => { //correction Fields vide
+		(customFieldsObj?.custom_fields || []).forEach((field, index) => {
             customFieldsTemplate[index] = {
                 field_name: field.value,
                 value: "Fill in the value based on your analysis"
@@ -405,7 +406,8 @@ class OllamaService {
         // Generate custom fields template for the prompt
         const customFieldsTemplate = {};
 
-        customFieldsObj.custom_fields.forEach((field, index) => {
+        //customFieldsObj.custom_fields.forEach((field, index) => { //correction bug
+		(this.customFields?.custom_fields || []).forEach((field, index) => {
             customFieldsTemplate[index] = {
                 field_name: field.value,
                 value: "Fill in the value based on your analysis"


### PR DESCRIPTION
## Description
When `CUSTOM_FIELDS` environment variable is not properly set or is undefined, the application crashes with:
```
TypeError: Cannot read properties of undefined (reading 'forEach')
    at OllamaService._buildPrompt (/app/services/ollamaService.js:275:39)
    at OllamaService._generateCustomFieldsTemplate (/app/services/ollamaService.js:408:39)
```

## Steps to Reproduce
1. Set `activateCustomFields: 'no'` in environment
2. Do not define `CUSTOM_FIELDS` environment variable
3. Process any document
4. Error occurs when trying to iterate over `customFieldsObj.custom_fields`

## Expected Behavior
Application should handle undefined or missing `CUSTOM_FIELDS` gracefully

## Actual Behavior
Application crashes and documents fail to process

## Environment
- Docker image: `ghcr.io/clusterzx/paperless-ai:latest`
- AI Provider: Ollama
- Model: gemma2:2b

## Proposed Fix
Add null safety checks:

**Line 275:**
```javascript
// Before
customFieldsObj.custom_fields.forEach((field, index) => {

// After
(customFieldsObj?.custom_fields || []).forEach((field, index) => {
```

**Line 408:**
```javascript
// Before
this.customFields.custom_fields.forEach((field, index) => {

// After
(this.customFields?.custom_fields || []).forEach((field, index) => {
```

## Additional Context
I have implemented and tested this fix in my fork: https://github.com/VOTRE-USERNAME/paperless-ai
The fix resolves the issue completely.
```

## 🔀 7. (Optionnel) Créer une Pull Request

Si vous voulez contribuer directement au projet :

1. Allez sur votre fork : `https://github.com/VOTRE-USERNAME/paperless-ai`
2. Cliquez sur "Contribute" → "Open pull request"
3. **Titre du PR :**
```
   Fix: Add null safety checks for customFields to prevent forEach crash