### PR TITLE
Fix: getOrCreateDocumentType ignores RESTRICT_TO_EXISTING_DOCUMENT_TYPES

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1117,19 +1117,33 @@ async searchForExistingDocumentType(documentType) {
   }
 }
 
-async getOrCreateDocumentType(name) {
+async getOrCreateDocumentType(name, options = {}) {
   this.initialize();
-  
+
+  // Check if we should restrict to existing document types
+  // Explicitly check options first, then env var
+  const restrictToExistingDocumentTypes = options.restrictToExistingDocumentTypes === true ||
+                                         (options.restrictToExistingDocumentTypes === undefined &&
+                                          process.env.RESTRICT_TO_EXISTING_DOCUMENT_TYPES === 'yes');
+
+  console.log(`[DEBUG] Processing document type with restrictToExistingDocumentTypes=${restrictToExistingDocumentTypes}`);
+
   try {
       // Suche nach existierendem document_type
       const existingDocType = await this.searchForExistingDocumentType(name);
       console.log("[DEBUG] Response Document Type Search: ", existingDocType);
-  
+
       if (existingDocType) {
           console.log(`[DEBUG] Found existing document type "${name}" with ID ${existingDocType.id}`);
           return existingDocType;
       }
-  
+
+      // If we're restricting to existing document types and none was found, return null
+      if (restrictToExistingDocumentTypes) {
+          console.log(`[DEBUG] Document type "${name}" does not exist and restrictions are enabled, returning null`);
+          return null;
+      }
+
       // Erstelle neuen document_type
       try {
           const createResponse = await this.client.post('/document_types/', { 


### PR DESCRIPTION
## Summary

`getOrCreateDocumentType` always creates new document types when no match is found, ignoring the `RESTRICT_TO_EXISTING_DOCUMENT_TYPES` environment variable. The sister function `getOrCreateCorrespondent` already handles this correctly.

This adds the same `options` parameter and env var check to `getOrCreateDocumentType`, returning `null` when restrictions are enabled and no existing type matches.

## Changes

- Added `options = {}` parameter to `getOrCreateDocumentType`
- Added restriction check mirroring `getOrCreateCorrespondent` (options flag → env var fallback)
- Returns `null` instead of creating a new type when restricted
- Fully backwards-compatible: existing callers pass no options, so behavior is controlled by env var

## Test plan

- [x] Verified with unit test: restriction enabled + no match → returns null
- [x] Verified with unit test: restriction disabled + no match → creates type
- [x] Verified with unit test: options override env var
- [x] Verified with unit test: existing type found → returned regardless of restriction setting