### PR TITLE
fix: respect USE_EXISTING_DATA setting for correspondents

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1280,8 +1280,12 @@ async getOrCreateDocumentType(name) {
       }
 
       if (currentDoc.correspondent && updates.correspondent) {
-        console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
-        delete updates.correspondent;
+        if (process.env.USE_EXISTING_DATA === 'yes') {
+          console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
+          delete updates.correspondent;
+        } else {
+          console.log('[DEBUG] Overwriting correspondent:', currentDoc.correspondent, '->', updates.correspondent);
+        }
       }
 
       let updateData;


### PR DESCRIPTION
## Bug Summary

When `USE_EXISTING_DATA` is set to `no` in the `.env` configuration, Paperless-AI should overwrite all existing document metadata (tags, document type, correspondent) with AI-generated values. However, correspondents are never overwritten — the existing correspondent is always kept, regardless of the `USE_EXISTING_DATA` setting.

The root cause is a hardcoded check in `services/paperlessService.js` (line ~1282) that unconditionally deletes the new correspondent from the update payload when the document already has one assigned.

## Steps to Reproduce

1. Set `USE_EXISTING_DATA=no` in `/app/data/.env`
2. Have a document with an incorrect correspondent already assigned (e.g. "DIT DELIGHT LIMITED" on an OpenAI invoice)
3. Tag the document so Paperless-AI picks it up for processing
4. Wait for the scheduled scan to process the document
5. The AI correctly identifies the correspondent (visible in logs: `correspondent: 'OpenAI OpCo, LLC'`)
6. Observe the log output: `[DEBUG] Document already has a correspondent, keeping existing one: 108`
7. The correspondent in Paperless-NGX remains unchanged

## Expected Behavior

With `USE_EXISTING_DATA=no`, the AI-suggested correspondent should overwrite the existing one.

## Actual Behavior

The existing correspondent is always kept. The code runs:

```javascript
if (currentDoc.correspondent && updates.correspondent) {
    console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
    delete updates.correspondent;
}
```

This block does not check `process.env.USE_EXISTING_DATA` — it unconditionally removes the new correspondent from the update.

## Docker Logs

```
# AI correctly identifies "OpenAI OpCo, LLC" as correspondent
Repsonse from AI service: {
  document: {
    title: 'Invoice TA4ZGZ7Y 0001',
    correspondent: 'OpenAI OpCo, LLC',
    ...
  }
}

# Paperless-AI creates the correspondent in Paperless-NGX
[DEBUG] Processing correspondent with restrictToExistingCorrespondents=false
[DEBUG] No correspondent with name "OpenAI OpCo, LLC" found
[DEBUG] Created new correspondent "OpenAI OpCo, LLC" with ID 268

# But then refuses to assign it, despite USE_EXISTING_DATA=no
[DEBUG] Current correspondent: 108
[DEBUG] New correspondent: 268
[DEBUG] Document already has a correspondent, keeping existing one: 108

# Final update is sent WITHOUT the correspondent field
[DEBUG] Final update data: {
  tags: [ 1, 8, 9, 10 ],
  title: 'Invoice',
  created: '2026-02-27',
  document_type: 59,
  ...
}
```

## Fix

Wrap the correspondent preservation in a `USE_EXISTING_DATA` check, matching the behavior users expect from the setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)