### PR TITLE
fix: detect recycled document IDs via content checksum (#871)

### DIFF
--- a/models/document.js
+++ b/models/document.js
@@ -28,6 +28,13 @@ const createTableMain = db.prepare(`
 `);
 createTableMain.run();
 
+// Migration: add content_checksum column for ID recycling detection (#871)
+try {
+  db.prepare(`ALTER TABLE processed_documents ADD COLUMN content_checksum TEXT`).run();
+} catch (e) {
+  // Column already exists — ignore
+}
+
 const createTableMetrics = db.prepare(`
   CREATE TABLE IF NOT EXISTS openai_metrics (
     id INTEGER PRIMARY KEY,
@@ -77,11 +84,13 @@ userTable.run();
 
 // Prepare statements for better performance
 const insertDocument = db.prepare(`
-  INSERT INTO processed_documents (document_id, title) 
-  VALUES (?, ?)
+  INSERT INTO processed_documents (document_id, title, content_checksum)
+  VALUES (?, ?, ?)
   ON CONFLICT(document_id) DO UPDATE SET
+    title = excluded.title,
+    content_checksum = excluded.content_checksum,
     last_updated = CURRENT_TIMESTAMP
-  WHERE document_id = ?
+  WHERE document_id = excluded.document_id
 `);
 
 const findDocument = db.prepare(
@@ -152,10 +161,9 @@ const getActiveProcessing = db.prepare(`
 
 
 module.exports = {
-  async addProcessedDocument(documentId, title) {
+  async addProcessedDocument(documentId, title, contentChecksum = null) {
     try {
-      // Bei UNIQUE constraint failure wird der existierende Eintrag aktualisiert
-      const result = insertDocument.run(documentId, title, documentId);
+      const result = insertDocument.run(documentId, title, contentChecksum);
       if (result.changes > 0) {
         console.log(`[DEBUG] Document ${title} ${result.lastInsertRowid ? 'added to' : 'updated in'} processed_documents`);
         return true;
@@ -209,10 +217,16 @@ module.exports = {
     }
   },
 
-  async isDocumentProcessed(documentId) {
+  async isDocumentProcessed(documentId, contentChecksum = null) {
     try {
       const row = findDocument.get(documentId);
-      return !!row;
+      if (!row) return false;
+      // If a checksum is provided and doesn't match, the document ID was recycled
+      if (contentChecksum && row.content_checksum && row.content_checksum !== contentChecksum) {
+        console.log(`[DEBUG] Document ${documentId} checksum mismatch (stored: ${row.content_checksum}, current: ${contentChecksum}) — ID was recycled, reprocessing`);
+        return false;
+      }
+      return true;
     } catch (error) {
       console.error('[ERROR] checking document:', error);
       // Im Zweifelsfall true zurückgeben, um doppelte Verarbeitung zu vermeiden

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1547,7 +1547,7 @@ try {
 });
 
 async function processDocument(doc, existingTags, existingCorrespondentList, existingDocumentTypesList, ownUserId, customPrompt = null) {
-  const isProcessed = await documentModel.isDocumentProcessed(doc.id);
+  const isProcessed = await documentModel.isDocumentProcessed(doc.id, doc.checksum);
   if (isProcessed) return null;
   await documentModel.setProcessingStatus(doc.id, doc.title, 'processing');
 
@@ -1726,13 +1726,13 @@ async function buildUpdateData(analysis, doc) {
 
 async function saveDocumentChanges(docId, updateData, analysis, originalData) {
   const { tags: originalTags, correspondent: originalCorrespondent, title: originalTitle } = originalData;
-  
+
   await Promise.all([
     documentModel.saveOriginalData(docId, originalTags, originalCorrespondent, originalTitle),
     paperlessService.updateDocument(docId, updateData),
-    documentModel.addProcessedDocument(docId, updateData.title),
+    documentModel.addProcessedDocument(docId, updateData.title, originalData.checksum),
     documentModel.addOpenAIMetrics(
-      docId, 
+      docId,
       analysis.metrics.promptTokens,
       analysis.metrics.completionTokens,
       analysis.metrics.totalTokens

--- a/server.js
+++ b/server.js
@@ -182,7 +182,7 @@ async function saveOpenApiSpec() {
 
 // Document processing functions
 async function processDocument(doc, existingTags, existingCorrespondentList, existingDocumentTypesList, ownUserId) {
-  const isProcessed = await documentModel.isDocumentProcessed(doc.id);
+  const isProcessed = await documentModel.isDocumentProcessed(doc.id, doc.checksum);
   if (isProcessed) return null;
   await documentModel.setProcessingStatus(doc.id, doc.title, 'processing');
 
@@ -330,11 +330,11 @@ async function buildUpdateData(analysis, doc) {
 
 async function saveDocumentChanges(docId, updateData, analysis, originalData) {
   const { tags: originalTags, correspondent: originalCorrespondent, title: originalTitle } = originalData;
-  
+
   await Promise.all([
     documentModel.saveOriginalData(docId, originalTags, originalCorrespondent, originalTitle),
     paperlessService.updateDocument(docId, updateData),
-    documentModel.addProcessedDocument(docId, updateData.title),
+    documentModel.addProcessedDocument(docId, updateData.title, originalData.checksum),
     documentModel.addOpenAIMetrics(
       docId, 
       analysis.metrics.promptTokens,


### PR DESCRIPTION
## Summary

- When Paperless-NGX recycles document IDs (after deletion), old cache entries in `processed_documents` caused the new document to be skipped entirely
- Adds `content_checksum` column to `processed_documents` with automatic migration
- `isDocumentProcessed()` now compares checksums — if they don't match, the document is treated as new
- Backwards-compatible: existing rows without checksum continue to work

## Test plan

- [ ] Process a document, verify `content_checksum` is stored in SQLite
- [ ] Delete the document in Paperless-NGX, upload a new document that gets the same ID
- [ ] Verify the new document is reprocessed (checksum mismatch detection in logs)
- [ ] Verify existing installations upgrade seamlessly (column auto-added)

Fixes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)