### PR TITLE
fix: set owner to null for created entities (#852)

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -288,7 +288,7 @@ class PaperlessService {
     
     try {
       // Versuche zuerst, den Tag zu erstellen
-      const response = await this.client.post('/tags/', { name: tagName });
+      const response = await this.client.post('/tags/', { name: tagName, owner: null });
       const newTag = response.data;
       console.log(`[DEBUG] Successfully created tag "${tagName}" with ID ${newTag.id}`);
       this.tagCache.set(normalizedName, newTag);
@@ -1051,8 +1051,9 @@ async searchForExistingCorrespondent(correspondent) {
     
         // Create new correspondent only if restrictions are not enabled
         try {
-            const createResponse = await this.client.post('/correspondents/', { 
-                name: name 
+            const createResponse = await this.client.post('/correspondents/', {
+                name: name,
+                owner: null
             });
             console.log(`[DEBUG] Created new correspondent "${name}" with ID ${createResponse.data.id}`);
             return createResponse.data;
@@ -1132,11 +1133,12 @@ async getOrCreateDocumentType(name) {
   
       // Erstelle neuen document_type
       try {
-          const createResponse = await this.client.post('/document_types/', { 
+          const createResponse = await this.client.post('/document_types/', {
               name: name,
               matching_algorithm: 1, // 1 = ANY
               match: "",  // Optional: Kann später angepasst werden
-              is_insensitive: true
+              is_insensitive: true,
+              owner: null
           });
           console.log(`[DEBUG] Created new document type "${name}" with ID ${createResponse.data.id}`);
           return createResponse.data;


### PR DESCRIPTION
## Summary

- Tags, correspondents, and document types created by paperless-ai were owned by the API service account user
- Other Paperless-NGX users couldn't see these entities (they appeared as "private")
- Adding `owner: null` to all `POST` requests for `/tags/`, `/correspondents/`, and `/document_types/` makes entities globally visible

## Test plan

- [ ] Trigger creation of a new tag via AI processing
- [ ] In Paperless-NGX admin, verify the tag has `owner: null` (not the AI service user)
- [ ] Verify the tag is visible to all users
- [ ] Repeat for correspondents and document types

Fixes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)