### PR TITLE
feat: add native Google Gemini provider support

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -88,6 +88,10 @@ module.exports = {
     deploymentName: process.env.AZURE_DEPLOYMENT_NAME || '',
     apiVersion: process.env.AZURE_API_VERSION || '2023-05-15'
   },
+  gemini: {
+    apiKey: process.env.GEMINI_API_KEY || '',
+    model: process.env.GEMINI_MODEL || 'gemini-2.0-flash'
+  },
   customFields: process.env.CUSTOM_FIELDS || '',
   aiProvider: process.env.AI_PROVIDER || 'openai',
   scanInterval: process.env.SCAN_INTERVAL || '*/30 * * * *',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@google/genai": "^1.0.0",
         "axios": "^1.8.2",
         "bcryptjs": "^3.0.2",
         "better-sqlite3": "^11.8.1",
@@ -313,6 +314,29 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@google/genai": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
+      "integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.12.6",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
@@ -565,6 +589,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
@@ -690,6 +724,12 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -993,6 +1033,15 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -1534,6 +1583,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/date-fns": {
@@ -2321,6 +2379,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2341,6 +2405,38 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2541,6 +2637,18 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2625,6 +2733,204 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/gaxios/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gaxios/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/gaxios/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/gaxios/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/gaxios/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gaxios/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gaxios/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -2725,6 +3031,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -3193,6 +3546,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -4068,6 +4430,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4301,9 +4685,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5572,6 +5956,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sqlite3": "^5.1.7",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "@google/genai": "^1.0.0",
     "tiktoken": "^1.0.20"
   },
   "devDependencies": {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -105,6 +105,7 @@ class FormManager {
         const ollamaSettings = document.getElementById('ollamaSettings');
         const customSettings = document.getElementById('customSettings');
         const azureSettings = document.getElementById('azureSettings');
+        const geminiSettings = document.getElementById('geminiSettings');
 
         // Get all provider-specific fields
         const openaiKey = document.getElementById('openaiKey');
@@ -117,6 +118,7 @@ class FormManager {
         const azureEndpoint = document.getElementById('azureEndpoint');
         const azureDeploymentName = document.getElementById('azureDeploymentName');
         const azureApiVersion = document.getElementById('azureApiVersion');
+        const geminiApiKey = document.getElementById('geminiApiKey');
 
         // Restriction settings
         const restrictToExistingTags = document.getElementById('restrictToExistingTags');
@@ -131,14 +133,15 @@ class FormManager {
         const externalApiBody = document.getElementById('externalApiBody');
         const externalApiTimeout = document.getElementById('externalApiTimeout');
         const externalApiTransformationTemplate = document.getElementById('externalApiTransformationTemplate');
-        
-        
+
+
         // Hide all settings sections first
         openaiSettings.classList.add('hidden');
         ollamaSettings.classList.add('hidden');
         customSettings.classList.add('hidden');
         azureSettings.classList.add('hidden');
-        
+        geminiSettings.classList.add('hidden');
+
         // Reset all required fields
         openaiKey.required = false;
         ollamaUrl.required = false;
@@ -150,7 +153,8 @@ class FormManager {
         azureEndpoint.required = false;
         azureDeploymentName.required = false;
         azureApiVersion.required = false;
-        
+        geminiApiKey.required = false;
+
         // Show and set required fields based on selected provider
         switch (provider) {
             case 'openai':
@@ -174,6 +178,10 @@ class FormManager {
                 azureEndpoint.required = true;
                 azureDeploymentName.required = true;
                 azureApiVersion.required = true;
+                break;
+            case 'gemini':
+                geminiSettings.classList.remove('hidden');
+                geminiApiKey.required = true;
                 break;
         }
     }

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -84,7 +84,8 @@ class FormManager {
         const ollamaSettings = document.getElementById('ollamaSettings');
         const customSettings = document.getElementById('customSettings');
         const azureSettings = document.getElementById('azureSettings');
-        
+        const geminiSettings = document.getElementById('geminiSettings');
+
         // Get all required fields
         const openaiKey = document.getElementById('openaiKey');
         const ollamaUrl = document.getElementById('ollamaUrl');
@@ -96,13 +97,15 @@ class FormManager {
         const azureEndpoint = document.getElementById('azureEndpoint');
         const azureModel = document.getElementById('azureApiVersion');
         const azureDeployment = document.getElementById('azureDeploymentName');
-        
+        const geminiApiKey = document.getElementById('geminiApiKey');
+
         // Hide all settings first
         openaiSettings.style.display = 'none';
         ollamaSettings.style.display = 'none';
         customSettings.style.display = 'none';
         azureSettings.style.display = 'none';
-        
+        geminiSettings.style.display = 'none';
+
         // Reset all required attributes
         openaiKey.required = false;
         ollamaUrl.required = false;
@@ -114,7 +117,8 @@ class FormManager {
         azureEndpoint.required = false;
         azureModel.required = false;
         azureDeployment.required = false;
-        
+        geminiApiKey.required = false;
+
         // Show and set required fields based on selected provider
         switch (provider) {
             case 'openai':
@@ -138,6 +142,10 @@ class FormManager {
                 azureEndpoint.required = true;
                 azureModel.required = true;
                 azureDeployment.required = true;
+                break;
+            case 'gemini':
+                geminiSettings.style.display = 'block';
+                geminiApiKey.required = true;
                 break;
         }
     }

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -5,6 +5,7 @@ const paperlessService = require('../services/paperlessService.js');
 const openaiService = require('../services/openaiService.js');
 const ollamaService = require('../services/ollamaService.js');
 const azureService = require('../services/azureService.js');
+const geminiService = require('../services/geminiService.js');
 const documentModel = require('../models/document.js');
 const AIServiceFactory = require('../services/aiServiceFactory');
 const debugService = require('../services/debugService.js');
@@ -1903,7 +1904,9 @@ router.get('/setup', async (req, res) => {
       AZURE_ENDPOINT: process.env.AZURE_ENDPOINT|| '',
       AZURE_API_KEY: process.env.AZURE_API_KEY || '',
       AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
-      AZURE_API_VERSION: process.env.AZURE_API_VERSION || ''
+      AZURE_API_VERSION: process.env.AZURE_API_VERSION || '',
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY || '',
+      GEMINI_MODEL: process.env.GEMINI_MODEL || 'gemini-2.0-flash'
     };
 
     // Check both configuration and users
@@ -2704,6 +2707,8 @@ router.get('/settings', async (req, res) => {
     AZURE_API_KEY: process.env.AZURE_API_KEY || '',
     AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
     AZURE_API_VERSION: process.env.AZURE_API_VERSION || '',
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY || '',
+    GEMINI_MODEL: process.env.GEMINI_MODEL || 'gemini-2.0-flash',
     RESTRICT_TO_EXISTING_TAGS: process.env.RESTRICT_TO_EXISTING_TAGS || 'no',
     RESTRICT_TO_EXISTING_CORRESPONDENTS: process.env.RESTRICT_TO_EXISTING_CORRESPONDENTS || 'no',
     RESTRICT_TO_EXISTING_DOCUMENT_TYPES: process.env.RESTRICT_TO_EXISTING_DOCUMENT_TYPES || 'no',
@@ -3056,6 +3061,15 @@ router.post('/manual/analyze', express.json(), async (req, res) => {
     } else if (process.env.AI_PROVIDER === 'azure') {
       const analyzeDocument = await azureService.analyzeDocument(content, existingTagsList, existingCorrespondentList, existingDocumentTypesList, id || []);
       return res.json(analyzeDocument);
+    } else if (process.env.AI_PROVIDER === 'gemini') {
+      const analyzeDocument = await geminiService.analyzeDocument(content, existingTagsList, existingCorrespondentList, existingDocumentTypesList, id || []);
+      await documentModel.addOpenAIMetrics(
+        id,
+        analyzeDocument.metrics.promptTokens,
+        analyzeDocument.metrics.completionTokens,
+        analyzeDocument.metrics.totalTokens
+      )
+      return res.json(analyzeDocument);
     } else {
       return res.status(500).json({ error: 'AI provider not configured' });
     }
@@ -3174,7 +3188,16 @@ router.post('/manual/playground', express.json(), async (req, res) => {
     } else if (process.env.AI_PROVIDER === 'azure') {
       const analyzeDocument = await azureService.analyzePlayground(content, prompt);
       await documentModel.addOpenAIMetrics(
-        documentId, 
+        documentId,
+        analyzeDocument.metrics.promptTokens,
+        analyzeDocument.metrics.completionTokens,
+        analyzeDocument.metrics.totalTokens
+      )
+      return res.json(analyzeDocument);
+    } else if (process.env.AI_PROVIDER === 'gemini') {
+      const analyzeDocument = await geminiService.analyzePlayground(content, prompt);
+      await documentModel.addOpenAIMetrics(
+        documentId,
         analyzeDocument.metrics.promptTokens,
         analyzeDocument.metrics.completionTokens,
         analyzeDocument.metrics.totalTokens
@@ -3443,7 +3466,7 @@ router.get('/health', async (req, res) => {
  *               aiProvider:
  *                 type: string
  *                 description: Selected AI provider for document analysis
- *                 enum: ["openai", "ollama", "custom", "azure"]
+ *                 enum: ["openai", "ollama", "custom", "azure", "gemini"]
  *                 example: "openai"
  *               openaiKey:
  *                 type: string
@@ -3618,11 +3641,13 @@ router.post('/setup', express.json(), async (req, res) => {
       azureEndpoint,
       azureApiKey,
       azureDeploymentName,
-      azureApiVersion
+      azureApiVersion,
+      geminiApiKey,
+      geminiModel
     } = req.body;
 
     // Log setup request with sensitive data redacted
-    const sensitiveKeys = ['paperlessToken', 'openaiKey', 'customApiKey', 'password', 'confirmPassword'];
+    const sensitiveKeys = ['paperlessToken', 'openaiKey', 'customApiKey', 'password', 'confirmPassword', 'geminiApiKey'];
     const redactedBody = Object.fromEntries(
       Object.entries(req.body).map(([key, value]) => [
       key,
@@ -3740,9 +3765,11 @@ router.post('/setup', express.json(), async (req, res) => {
       AZURE_ENDPOINT: azureEndpoint || '',
       AZURE_API_KEY: azureApiKey || '',
       AZURE_DEPLOYMENT_NAME: azureDeploymentName || '',
-      AZURE_API_VERSION: azureApiVersion || ''
+      AZURE_API_VERSION: azureApiVersion || '',
+      GEMINI_API_KEY: geminiApiKey || '',
+      GEMINI_MODEL: geminiModel || 'gemini-2.0-flash'
     };
-    
+
     // Validate AI provider config
     if (aiProvider === 'openai') {
       const isOpenAIValid = await setupService.validateOpenAIConfig(openaiKey);
@@ -3777,6 +3804,13 @@ router.post('/setup', express.json(), async (req, res) => {
       if (!isAzureValid) {
         return res.status(400).json({
           error: 'Azure connection failed. Please check URL, API Key, Deployment Name and API Version.'
+        });
+      }
+    } else if (aiProvider === 'gemini') {
+      const isGeminiValid = await setupService.validateGeminiConfig(geminiApiKey, geminiModel);
+      if (!isGeminiValid) {
+        return res.status(400).json({
+          error: 'Gemini connection failed. Please check API Key and Model.'
         });
       }
     }
@@ -3844,7 +3878,7 @@ router.post('/setup', express.json(), async (req, res) => {
  *               aiProvider:
  *                 type: string
  *                 description: Selected AI provider for document analysis
- *                 enum: ["openai", "ollama", "custom", "azure"]
+ *                 enum: ["openai", "ollama", "custom", "azure", "gemini"]
  *                 example: "openai"
  *               openaiKey:
  *                 type: string
@@ -4025,7 +4059,9 @@ router.post('/settings', express.json(), async (req, res) => {
       azureEndpoint,
       azureApiKey,
       azureDeploymentName,
-      azureApiVersion
+      azureApiVersion,
+      geminiApiKey,
+      geminiModel
     } = req.body;
 
     //replace equal char in system prompt
@@ -4069,6 +4105,8 @@ router.post('/settings', express.json(), async (req, res) => {
       AZURE_API_KEY: process.env.AZURE_API_KEY || '',
       AZURE_DEPLOYMENT_NAME: process.env.AZURE_DEPLOYMENT_NAME || '',
       AZURE_API_VERSION: process.env.AZURE_API_VERSION || '',
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY || '',
+      GEMINI_MODEL: process.env.GEMINI_MODEL || 'gemini-2.0-flash',
       RESTRICT_TO_EXISTING_TAGS: process.env.RESTRICT_TO_EXISTING_TAGS || 'no',
       RESTRICT_TO_EXISTING_CORRESPONDENTS: process.env.RESTRICT_TO_EXISTING_CORRESPONDENTS || 'no',
       RESTRICT_TO_EXISTING_DOCUMENT_TYPES: process.env.RESTRICT_TO_EXISTING_DOCUMENT_TYPES || 'no',
@@ -4182,6 +4220,18 @@ router.post('/settings', express.json(), async (req, res) => {
         if(azureApiKey) updatedConfig.AZURE_API_KEY = azureApiKey;
         if(azureDeploymentName) updatedConfig.AZURE_DEPLOYMENT_NAME = azureDeploymentName;
         if(azureApiVersion) updatedConfig.AZURE_API_VERSION = azureApiVersion;
+      } else if (aiProvider === 'gemini') {
+        const isGeminiValid = await setupService.validateGeminiConfig(
+          geminiApiKey || currentConfig.GEMINI_API_KEY,
+          geminiModel || currentConfig.GEMINI_MODEL
+        );
+        if (!isGeminiValid) {
+          return res.status(400).json({
+            error: 'Gemini connection failed. Please check API Key and Model.'
+          });
+        }
+        if(geminiApiKey) updatedConfig.GEMINI_API_KEY = geminiApiKey;
+        if(geminiModel) updatedConfig.GEMINI_MODEL = geminiModel;
       }
     }
 

--- a/services/aiServiceFactory.js
+++ b/services/aiServiceFactory.js
@@ -3,6 +3,7 @@ const openaiService = require('./openaiService');
 const ollamaService = require('./ollamaService');
 const customService = require('./customService');
 const azureService = require('./azureService');
+const geminiService = require('./geminiService');
 
 class AIServiceFactory {
   static getService() {
@@ -16,6 +17,8 @@ class AIServiceFactory {
         return customService;
       case 'azure':
         return azureService;
+      case 'gemini':
+        return geminiService;
     }
   }
 }

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -194,9 +194,41 @@ class ChatService {
           messages: chatData.messages,
           stream: true,
         });
-        
+
         for await (const chunk of stream) {
           const content = chunk.choices[0]?.delta?.content || '';
+          if (content) {
+            fullResponse += content;
+            res.write(`data: ${JSON.stringify({ content })}\n\n`);
+          }
+        }
+      } else if (aiProvider === 'gemini') {
+        const { GoogleGenAI } = require('@google/genai');
+        const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+
+        // Extract system message and build history for Gemini
+        const systemMessage = chatData.messages.find(m => m.role === 'system');
+        const historyMessages = chatData.messages.filter(m => m.role !== 'system' && m !== chatData.messages[chatData.messages.length - 1]);
+
+        const geminiHistory = historyMessages.map(m => ({
+          role: m.role === 'assistant' ? 'model' : m.role,
+          parts: [{ text: m.content }]
+        }));
+
+        const chat = ai.chats.create({
+          model: process.env.GEMINI_MODEL || 'gemini-2.0-flash',
+          history: geminiHistory,
+          config: {
+            systemInstruction: systemMessage ? systemMessage.content : undefined,
+          },
+        });
+
+        const stream = await chat.sendMessageStream({
+          message: userMessage,
+        });
+
+        for await (const chunk of stream) {
+          const content = chunk.text || '';
           if (content) {
             fullResponse += content;
             res.write(`data: ${JSON.stringify({ content })}\n\n`);

--- a/services/geminiService.js
+++ b/services/geminiService.js
@@ -1,0 +1,399 @@
+const {
+  calculateTokens,
+  calculateTotalPromptTokens,
+  truncateToTokenLimit
+} = require('./serviceUtils');
+const { GoogleGenAI } = require('@google/genai');
+const config = require('../config/config');
+const paperlessService = require('./paperlessService');
+const fs = require('fs').promises;
+const path = require('path');
+const RestrictionPromptService = require('./restrictionPromptService');
+
+class GeminiService {
+  constructor() {
+    this.client = null;
+  }
+
+  initialize() {
+    if (!this.client && config.aiProvider === 'gemini') {
+      this.client = new GoogleGenAI({ apiKey: config.gemini.apiKey });
+    }
+  }
+
+  async analyzeDocument(content, existingTags = [], existingCorrespondentList = [], existingDocumentTypesList = [], id, customPrompt = null, options = {}) {
+    const cachePath = path.join('./public/images', `${id}.png`);
+    try {
+      this.initialize();
+      const now = new Date();
+      const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+
+      if (!this.client) {
+        throw new Error('Gemini client not initialized');
+      }
+
+      // Handle thumbnail caching
+      try {
+        await fs.access(cachePath);
+        console.log('[DEBUG] Thumbnail already cached');
+      } catch (err) {
+        console.log('Thumbnail not cached, fetching from Paperless');
+
+        const thumbnailData = await paperlessService.getThumbnailImage(id);
+
+        if (!thumbnailData) {
+          console.warn('Thumbnail nicht gefunden');
+        }
+
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, thumbnailData);
+      }
+
+      // Format existing tags
+      let existingTagsList = existingTags.join(', ');
+
+      // Get external API data if available and validate it
+      let externalApiData = options.externalApiData || null;
+      let validatedExternalApiData = null;
+
+      if (externalApiData) {
+        try {
+          validatedExternalApiData = await this._validateAndTruncateExternalApiData(externalApiData);
+          console.log('[DEBUG] External API data validated and included');
+        } catch (error) {
+          console.warn('[WARNING] External API data validation failed:', error.message);
+          validatedExternalApiData = null;
+        }
+      }
+
+      let systemPrompt = '';
+      let promptTags = '';
+      const model = config.gemini.model;
+
+      // Parse CUSTOM_FIELDS from environment variable
+      let customFieldsObj;
+      try {
+        customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
+      } catch (error) {
+        console.error('Failed to parse CUSTOM_FIELDS:', error);
+        customFieldsObj = { custom_fields: [] };
+      }
+
+      // Generate custom fields template for the prompt
+      const customFieldsTemplate = {};
+
+      customFieldsObj.custom_fields.forEach((field, index) => {
+        customFieldsTemplate[index] = {
+          field_name: field.value,
+          value: "Fill in the value based on your analysis"
+        };
+      });
+
+      // Convert template to string for replacement and wrap in custom_fields
+      const customFieldsStr = '"custom_fields": ' + JSON.stringify(customFieldsTemplate, null, 2)
+        .split('\n')
+        .map(line => '    ' + line)
+        .join('\n');
+
+      // Get system prompt based on configuration
+      if (config.useExistingData === 'yes' && config.restrictToExistingTags === 'no' && config.restrictToExistingCorrespondents === 'no') {
+        systemPrompt = `
+        Pre-existing tags: ${existingTagsList}\n\n
+        Pre-existing correspondents: ${existingCorrespondentList}\n\n
+        Pre-existing document types: ${existingDocumentTypesList.join(', ')}\n\n
+        ` + process.env.SYSTEM_PROMPT + '\n\n' + config.mustHavePrompt.replace('%CUSTOMFIELDS%', customFieldsStr);
+        promptTags = '';
+      } else {
+        config.mustHavePrompt = config.mustHavePrompt.replace('%CUSTOMFIELDS%', customFieldsStr);
+        systemPrompt = process.env.SYSTEM_PROMPT + '\n\n' + config.mustHavePrompt;
+        promptTags = '';
+      }
+
+      // Process placeholder replacements in system prompt
+      systemPrompt = RestrictionPromptService.processRestrictionsInPrompt(
+        systemPrompt,
+        existingTags,
+        existingCorrespondentList,
+        existingDocumentTypesList,
+        config
+      );
+
+      // Include validated external API data if available
+      if (validatedExternalApiData) {
+        systemPrompt += `\n\nAdditional context from external API:\n${validatedExternalApiData}`;
+      }
+
+      if (process.env.USE_PROMPT_TAGS === 'yes') {
+        promptTags = process.env.PROMPT_TAGS;
+        systemPrompt = `
+        Take these tags and try to match one or more to the document content.\n\n
+        ` + config.specialPromptPreDefinedTags;
+      }
+
+      // Custom prompt override if provided
+      if (customPrompt) {
+        console.log('[DEBUG] Replace system prompt with custom prompt');
+        systemPrompt = customPrompt + '\n\n' + config.mustHavePrompt;
+      }
+
+      // Calculate tokens AFTER all prompt modifications are complete
+      const totalPromptTokens = await calculateTotalPromptTokens(
+        systemPrompt,
+        process.env.USE_PROMPT_TAGS === 'yes' ? [promptTags] : [],
+        model
+      );
+
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens);
+      const availableTokens = maxTokens - reservedTokens;
+
+      // Validate that we have positive available tokens
+      if (availableTokens <= 0) {
+        console.warn(`[WARNING] No available tokens for content. Reserved: ${reservedTokens}, Max: ${maxTokens}`);
+        throw new Error('Token limit exceeded: prompt too large for available token limit');
+      }
+
+      console.log(`[DEBUG] Token calculation - Prompt: ${totalPromptTokens}, Reserved: ${reservedTokens}, Available: ${availableTokens}`);
+      console.log(`[DEBUG] Use existing data: ${config.useExistingData}, Restrictions applied based on useExistingData setting`);
+      console.log(`[DEBUG] External API data: ${validatedExternalApiData ? 'included' : 'none'}`);
+
+      const truncatedContent = await truncateToTokenLimit(content, availableTokens, model);
+
+      const response = await this.client.models.generateContent({
+        model: model,
+        contents: truncatedContent,
+        config: {
+          systemInstruction: systemPrompt,
+          temperature: 0.3,
+        },
+      });
+
+      // Check for safety filter blocks
+      if (!response.text) {
+        throw new Error('Gemini returned empty response - content may have been blocked by safety filters');
+      }
+
+      // Log token usage
+      console.log(`[DEBUG] [${timestamp}] Gemini request sent`);
+
+      const usage = response.usageMetadata || {};
+      const mappedUsage = {
+        promptTokens: usage.promptTokenCount || 0,
+        completionTokens: usage.candidatesTokenCount || 0,
+        totalTokens: usage.totalTokenCount || 0
+      };
+
+      console.log(`[DEBUG] [${timestamp}] Total tokens: ${mappedUsage.totalTokens}`);
+
+      let jsonContent = response.text;
+      jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+      let parsedResponse;
+      try {
+        parsedResponse = JSON.parse(jsonContent);
+        fs.appendFile('./logs/response.txt', jsonContent, (err) => {
+          if (err) throw err;
+        });
+      } catch (error) {
+        console.error('Failed to parse JSON response:', error);
+        throw new Error('Invalid JSON response from API');
+      }
+
+      // Validate response structure
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        throw new Error('Invalid response structure: missing tags array or correspondent string');
+      }
+
+      return {
+        document: parsedResponse,
+        metrics: mappedUsage,
+        truncated: truncatedContent.length < content.length
+      };
+    } catch (error) {
+      console.error('Failed to analyze document:', error);
+      return {
+        document: { tags: [], correspondent: null },
+        metrics: null,
+        error: error.message
+      };
+    }
+  }
+
+  /**
+   * Validate and truncate external API data to prevent token overflow
+   * @param {any} apiData - The external API data to validate
+   * @param {number} maxTokens - Maximum tokens allowed for external data (default: 500)
+   * @returns {string} - Validated and potentially truncated data string
+   */
+  async _validateAndTruncateExternalApiData(apiData, maxTokens = 500) {
+    if (!apiData) {
+      return null;
+    }
+
+    const dataString = typeof apiData === 'object'
+      ? JSON.stringify(apiData, null, 2)
+      : String(apiData);
+
+    // Calculate tokens for the data
+    const dataTokens = await calculateTokens(dataString, config.gemini.model);
+
+    if (dataTokens > maxTokens) {
+      console.warn(`[WARNING] External API data (${dataTokens} tokens) exceeds limit (${maxTokens}), truncating`);
+      return await truncateToTokenLimit(dataString, maxTokens, config.gemini.model);
+    }
+
+    console.log(`[DEBUG] External API data validated: ${dataTokens} tokens`);
+    return dataString;
+  }
+
+  async analyzePlayground(content, prompt) {
+    const musthavePrompt = `
+    Return the result EXCLUSIVELY as a JSON object. The Tags and Title MUST be in the language that is used in the document.:
+        {
+          "title": "xxxxx",
+          "correspondent": "xxxxxxxx",
+          "tags": ["Tag1", "Tag2", "Tag3", "Tag4"],
+          "document_date": "YYYY-MM-DD",
+          "language": "en/de/es/..."
+        }`;
+
+    try {
+      this.initialize();
+      const now = new Date();
+      const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+
+      if (!this.client) {
+        throw new Error('Gemini client not initialized');
+      }
+
+      // Calculate total prompt tokens including musthavePrompt
+      const totalPromptTokens = await calculateTotalPromptTokens(
+        prompt + musthavePrompt
+      );
+
+      // Calculate available tokens
+      const maxTokens = Number(config.tokenLimit);
+      const reservedTokens = totalPromptTokens + Number(config.responseTokens);
+      const availableTokens = maxTokens - reservedTokens;
+
+      // Truncate content if necessary
+      const truncatedContent = await truncateToTokenLimit(content, availableTokens);
+
+      const response = await this.client.models.generateContent({
+        model: config.gemini.model,
+        contents: truncatedContent,
+        config: {
+          systemInstruction: prompt + musthavePrompt,
+          temperature: 0.3,
+        },
+      });
+
+      // Check for safety filter blocks
+      if (!response.text) {
+        throw new Error('Gemini returned empty response - content may have been blocked by safety filters');
+      }
+
+      // Log token usage
+      console.log(`[DEBUG] [${timestamp}] Gemini request sent`);
+
+      const usage = response.usageMetadata || {};
+      const mappedUsage = {
+        promptTokens: usage.promptTokenCount || 0,
+        completionTokens: usage.candidatesTokenCount || 0,
+        totalTokens: usage.totalTokenCount || 0
+      };
+
+      console.log(`[DEBUG] [${timestamp}] Total tokens: ${mappedUsage.totalTokens}`);
+
+      let jsonContent = response.text;
+      jsonContent = jsonContent.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+      let parsedResponse;
+      try {
+        parsedResponse = JSON.parse(jsonContent);
+      } catch (error) {
+        console.error('Failed to parse JSON response:', error);
+        throw new Error('Invalid JSON response from API');
+      }
+
+      // Validate response structure
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        throw new Error('Invalid response structure: missing tags array or correspondent string');
+      }
+
+      return {
+        document: parsedResponse,
+        metrics: mappedUsage,
+        truncated: truncatedContent.length < content.length
+      };
+    } catch (error) {
+      console.error('Failed to analyze document:', error);
+      return {
+        document: { tags: [], correspondent: null },
+        metrics: null,
+        error: error.message
+      };
+    }
+  }
+
+  /**
+   * Generate text based on a prompt
+   * @param {string} prompt - The prompt to generate text from
+   * @returns {Promise<string>} - The generated text
+   */
+  async generateText(prompt) {
+    try {
+      this.initialize();
+
+      if (!this.client) {
+        throw new Error('Gemini client not initialized');
+      }
+
+      const response = await this.client.models.generateContent({
+        model: config.gemini.model,
+        contents: prompt,
+        config: {
+          temperature: 0.7,
+        },
+      });
+
+      if (!response.text) {
+        throw new Error('Gemini returned empty response');
+      }
+
+      return response.text;
+    } catch (error) {
+      console.error('Error generating text with Gemini:', error);
+      throw error;
+    }
+  }
+
+  async checkStatus() {
+    try {
+      this.initialize();
+
+      if (!this.client) {
+        throw new Error('Gemini client not initialized');
+      }
+
+      const response = await this.client.models.generateContent({
+        model: config.gemini.model,
+        contents: 'Ping',
+        config: {
+          temperature: 0.7,
+        },
+      });
+
+      if (!response.text) {
+        return { status: 'error' };
+      }
+
+      return { status: 'ok', model: config.gemini.model };
+    } catch (error) {
+      console.error('Error checking Gemini status:', error);
+      return { status: 'error' };
+    }
+  }
+}
+
+module.exports = new GeminiService();

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const { OpenAI } = require('openai');
 const config = require('../config/config');
 const AzureOpenAI = require('openai').AzureOpenAI;
+const { GoogleGenAI } = require('@google/genai');
 
 class SetupService {
   constructor() {
@@ -151,6 +152,27 @@ class SetupService {
     }
   }
 
+  async validateGeminiConfig(apiKey, model) {
+    if (config.CONFIGURED === false) {
+      try {
+        const ai = new GoogleGenAI({ apiKey });
+        const response = await ai.models.generateContent({
+          model: model || 'gemini-2.0-flash',
+          contents: 'Test',
+        });
+        const now = new Date();
+        const timestamp = now.toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short' });
+        console.log(`[DEBUG] [${timestamp}] Gemini request sent`);
+        return !!response.text;
+      } catch (error) {
+        console.error('Gemini validation error:', error.message);
+        return false;
+      }
+    } else {
+      return true;
+    }
+  }
+
   async validateConfig(config) {
     // Validate Paperless config
     const paperlessApiUrl = config.PAPERLESS_API_URL.replace(/\/api/g, '');
@@ -199,6 +221,14 @@ class SetupService {
       );
       if (!azureValid) {
         throw new Error('Invalid Azure configuration');
+      }
+    } else if (aiProvider === 'gemini') {
+      const geminiValid = await this.validateGeminiConfig(
+        config.GEMINI_API_KEY,
+        config.GEMINI_MODEL
+      );
+      if (!geminiValid) {
+        throw new Error('Invalid Gemini configuration');
       }
     }
 

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -274,6 +274,7 @@
                                         <option value="ollama" <%= config.AI_PROVIDER === 'ollama' ? 'selected' : '' %>>Ollama (Local LLM)</option>
                                         <option value="custom" <%= config.AI_PROVIDER === 'custom' ? 'selected' : '' %>>Custom</option>
                                         <option value="azure" <%= config.AI_PROVIDER === 'azure' ? 'selected' : '' %>>Azure</option>
+                                        <option value="gemini" <%= config.AI_PROVIDER === 'gemini' ? 'selected' : '' %>>Google Gemini</option>
                                     </select>
                                 </div>
 
@@ -408,6 +409,36 @@
                                                value="<%= config.AZURE_API_VERSION %>"
                                                class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                                placeholder="Enter API version">
+                                    </div>
+                                </div>
+
+                                <!-- Gemini Settings -->
+                                <div id="geminiSettings" class="space-y-4">
+                                    <div class="space-y-2">
+                                        <label for="geminiApiKey" class="text-sm font-medium">Gemini API Key</label>
+                                        <div class="relative">
+                                            <input type="password"
+                                                id="geminiApiKey"
+                                                name="geminiApiKey"
+                                                value="<%= config.GEMINI_API_KEY %>"
+                                                class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                            <button type="button" class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" data-input="geminiApiKey">
+                                                <i class="fas fa-eye"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <div class="space-y-2">
+                                        <label for="geminiModel" class="text-sm font-medium">Gemini Model</label>
+                                        <select id="geminiModel"
+                                                name="geminiModel"
+                                                class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                            <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
+                                            <option value="gemini-2.5-flash" <%= config.GEMINI_MODEL === 'gemini-2.5-flash' ? 'selected' : '' %>>Gemini 2.5 Flash</option>
+                                            <option value="gemini-2.5-pro" <%= config.GEMINI_MODEL === 'gemini-2.5-pro' ? 'selected' : '' %>>Gemini 2.5 Pro</option>
+                                            <option value="gemini-1.5-pro" <%= config.GEMINI_MODEL === 'gemini-1.5-pro' ? 'selected' : '' %>>Gemini 1.5 Pro</option>
+                                            <option value="gemini-1.5-flash" <%= config.GEMINI_MODEL === 'gemini-1.5-flash' ? 'selected' : '' %>>Gemini 1.5 Flash</option>
+                                        </select>
                                     </div>
                                 </div>
 

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -433,9 +433,11 @@
                                         <select id="geminiModel"
                                                 name="geminiModel"
                                                 class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                                            <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
+                                            <option value="gemini-3-flash-preview" <%= config.GEMINI_MODEL === 'gemini-3-flash-preview' ? 'selected' : '' %>>Gemini 3 Flash Preview</option>
+                                            <option value="gemini-3-pro-preview" <%= config.GEMINI_MODEL === 'gemini-3-pro-preview' ? 'selected' : '' %>>Gemini 3 Pro Preview</option>
                                             <option value="gemini-2.5-flash" <%= config.GEMINI_MODEL === 'gemini-2.5-flash' ? 'selected' : '' %>>Gemini 2.5 Flash</option>
                                             <option value="gemini-2.5-pro" <%= config.GEMINI_MODEL === 'gemini-2.5-pro' ? 'selected' : '' %>>Gemini 2.5 Pro</option>
+                                            <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
                                             <option value="gemini-1.5-pro" <%= config.GEMINI_MODEL === 'gemini-1.5-pro' ? 'selected' : '' %>>Gemini 1.5 Pro</option>
                                             <option value="gemini-1.5-flash" <%= config.GEMINI_MODEL === 'gemini-1.5-flash' ? 'selected' : '' %>>Gemini 1.5 Flash</option>
                                         </select>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -209,6 +209,9 @@
                                             <option value="azure" <%= config.AI_PROVIDER === 'azure' ? 'selected' : '' %>>
                                                 Azure
                                             </option>
+                                            <option value="gemini" <%= config.AI_PROVIDER === 'gemini' ? 'selected' : '' %>>
+                                                Google Gemini
+                                            </option>
                                         </select>
                                     </div>
 
@@ -344,6 +347,36 @@
                                                    value="<%= config.AZURE_API_VERSION %>"
                                                    class="modern-input"
                                                    placeholder="Enter API version">
+                                        </div>
+                                    </div>
+
+                                    <!-- Gemini Settings -->
+                                    <div id="geminiSettings" class="provider-settings">
+                                        <div class="form-group">
+                                            <label for="geminiApiKey">Gemini API Key</label>
+                                            <div class="password-input">
+                                                <input type="password"
+                                                       id="geminiApiKey"
+                                                       name="geminiApiKey"
+                                                       value="<%= config.GEMINI_API_KEY %>"
+                                                       class="modern-input">
+                                                <button type="button" class="password-toggle" data-input="geminiApiKey">
+                                                    <i class="fas fa-eye"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                        <div class="form-group">
+                                            <label for="geminiModel">Gemini Model</label>
+                                            <select id="geminiModel"
+                                                    name="geminiModel"
+                                                    class="modern-input">
+                                                <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
+                                                <option value="gemini-2.5-flash" <%= config.GEMINI_MODEL === 'gemini-2.5-flash' ? 'selected' : '' %>>Gemini 2.5 Flash</option>
+                                                <option value="gemini-2.5-pro" <%= config.GEMINI_MODEL === 'gemini-2.5-pro' ? 'selected' : '' %>>Gemini 2.5 Pro</option>
+                                                <option value="gemini-1.5-pro" <%= config.GEMINI_MODEL === 'gemini-1.5-pro' ? 'selected' : '' %>>Gemini 1.5 Pro</option>
+                                                <option value="gemini-1.5-flash" <%= config.GEMINI_MODEL === 'gemini-1.5-flash' ? 'selected' : '' %>>Gemini 1.5 Flash</option>
+                                            </select>
                                         </div>
                                     </div>
 

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -371,9 +371,11 @@
                                             <select id="geminiModel"
                                                     name="geminiModel"
                                                     class="modern-input">
-                                                <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
+                                                <option value="gemini-3-flash-preview" <%= config.GEMINI_MODEL === 'gemini-3-flash-preview' ? 'selected' : '' %>>Gemini 3 Flash Preview</option>
+                                                <option value="gemini-3-pro-preview" <%= config.GEMINI_MODEL === 'gemini-3-pro-preview' ? 'selected' : '' %>>Gemini 3 Pro Preview</option>
                                                 <option value="gemini-2.5-flash" <%= config.GEMINI_MODEL === 'gemini-2.5-flash' ? 'selected' : '' %>>Gemini 2.5 Flash</option>
                                                 <option value="gemini-2.5-pro" <%= config.GEMINI_MODEL === 'gemini-2.5-pro' ? 'selected' : '' %>>Gemini 2.5 Pro</option>
+                                                <option value="gemini-2.0-flash" <%= config.GEMINI_MODEL === 'gemini-2.0-flash' ? 'selected' : '' %>>Gemini 2.0 Flash</option>
                                                 <option value="gemini-1.5-pro" <%= config.GEMINI_MODEL === 'gemini-1.5-pro' ? 'selected' : '' %>>Gemini 1.5 Pro</option>
                                                 <option value="gemini-1.5-flash" <%= config.GEMINI_MODEL === 'gemini-1.5-flash' ? 'selected' : '' %>>Gemini 1.5 Flash</option>
                                             </select>


### PR DESCRIPTION
## Summary
- Add native Google Gemini AI provider using the official `@google/generative-ai` SDK (no OpenAI compatibility layer)
- Support Gemini 2.0 Flash, Gemini 2.5 Flash/Pro, and Gemini 3 Flash/Pro Preview models
- Add Gemini configuration to setup wizard and settings pages

## Changes
- New `services/geminiService.js` with native Gemini SDK integration
- Updated `services/aiServiceFactory.js` to route `gemini` provider
- Updated `services/chatService.js` with Gemini chat support
- Updated `services/setupService.js` with Gemini validation
- Updated setup and settings views with Gemini model dropdowns
- Updated `config/config.js` with Gemini configuration block

## Test plan
- [ ] Select "gemini" as AI provider in setup wizard
- [ ] Verify Gemini API key validation works
- [ ] Process a document with Gemini and verify tags/correspondent/title
- [ ] Test Gemini chat functionality
- [ ] Verify model dropdown shows all Gemini model options

🤖 Generated with [Claude Code](https://claude.com/claude-code)