### PR TITLE
Fix: Normalize API URL to prevent double /api/ prefix

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -17,7 +17,7 @@ class PaperlessService {
   initialize() {
     if (!this.client && config.paperless.apiUrl && config.paperless.apiToken) {
       this.client = axios.create({
-        baseURL: config.paperless.apiUrl,
+        baseURL: config.paperless.apiUrl.replace(/\/api$/, '') + '/api',
         headers: {
           'Authorization': `Token ${config.paperless.apiToken}`,
           'Content-Type': 'application/json'
@@ -114,7 +114,7 @@ class PaperlessService {
 
   async initializeWithCredentials(apiUrl, apiToken) {
     this.client = axios.create({
-      baseURL: apiUrl,
+      baseURL: apiUrl.replace(/\/api$/, '') + '/api',
       headers: {
         'Authorization': `Token ${apiToken}`,
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
Fixes issue #880 where the setup wizard appends /api to PAPERLESS_API_URL, causing double /api/api/ paths.

## Changes
- Modified `initialize()` to strip trailing `/api` from config URL before appending it
- Applied same fix to `initializeWithCredentials()` method
- This ensures consistent URL handling regardless of how the URL is configured

## Testing
The fix ensures that whether the user enters the URL with or without `/api`, the axios client will always use the correct single `/api` prefix.

Closes #880