### PR TITLE
fix: use conservative token estimation and config.responseTokens for num_ctx calculation

### DIFF
--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -136,7 +136,7 @@ class OllamaService {
 
             // Calculate context window size
             const promptTokenCount = this._calculatePromptTokenCount(prompt);
-            const numCtx = this._calculateNumCtx(promptTokenCount, 1024);
+            const numCtx = this._calculateNumCtx(promptTokenCount, Number(config.responseTokens));
 
             console.log(`[DEBUG] Use existing data: ${config.useExistingData}, Restrictions applied based on useExistingData setting`);
             console.log(`[DEBUG] External API data: ${validatedExternalApiData ? 'included' : 'none'}`);
@@ -183,16 +183,17 @@ class OllamaService {
      */
     async analyzePlayground(content, prompt) {
         try {
-            // Calculate context window size
-            const promptTokenCount = await calculateTokens(prompt);
-            const numCtx = this._calculateNumCtx(promptTokenCount, 1024);
+            // Calculate context window size — include both prompt and content
+            const fullPrompt = prompt + "\n\n" + JSON.stringify(content);
+            const promptTokenCount = this._calculatePromptTokenCount(fullPrompt);
+            const numCtx = this._calculateNumCtx(promptTokenCount, Number(config.responseTokens));
 
             // Generate playground system prompt (simpler than full analysis)
             const systemPrompt = this._generatePlaygroundSystemPrompt();
 
             // Call Ollama API
             const response = await this._callOllamaAPI(
-                prompt + "\n\n" + JSON.stringify(content),
+                fullPrompt,
                 systemPrompt,
                 numCtx,
                 this.playgroundSchema
@@ -375,13 +376,13 @@ class OllamaService {
             ? JSON.stringify(apiData, null, 2)
             : String(apiData);
 
-        // Calculate tokens for the data (using simple estimation for Ollama)
-        const dataTokens = Math.ceil(dataString.length / 4);
+        // Calculate tokens for the data (conservative 2 chars/token for non-English)
+        const dataTokens = Math.ceil(dataString.length / 2);
 
         if (dataTokens > maxTokens) {
             console.warn(`[WARNING] External API data (${dataTokens} tokens) exceeds limit (${maxTokens}), truncating`);
             // Simple truncation based on character count
-            const maxChars = maxTokens * 4;
+            const maxChars = maxTokens * 2;
             return dataString.substring(0, maxChars);
         }
 
@@ -474,7 +475,10 @@ class OllamaService {
      * @returns {number} Estimated token count
      */
     _calculatePromptTokenCount(prompt) {
-        return Math.ceil(prompt.length / 4);
+        // Use conservative 2 chars/token estimate to avoid truncation
+        // with non-English models (CJK, German, etc.) where tokenization
+        // produces roughly 2 chars per token instead of ~4 for English
+        return Math.ceil(prompt.length / 2);
     }
 
     /**
@@ -685,7 +689,7 @@ class OllamaService {
         try {
             // Calculate context window size based on prompt length
             const promptTokenCount = this._calculatePromptTokenCount(prompt);
-            const numCtx = this._calculateNumCtx(promptTokenCount, 512);
+            const numCtx = this._calculateNumCtx(promptTokenCount, Number(config.responseTokens));
 
             // Simple system prompt for text generation
             const systemPrompt = `You are a helpful assistant. Generate a clear, concise, and informative response to the user's question or request.`;


### PR DESCRIPTION
## Summary

Fixes #913, #745

The context window calculation (`_calculatePromptTokenCount`) assumes ~4 characters per token, which works for English but severely underestimates token count for non-English models (German, CJK, etc.) where tokenization produces roughly 2 chars per token. This causes Ollama to truncate prompts silently.

Additionally, `_calculateNumCtx` was called with hardcoded response token values (1024, 512) instead of using the existing `RESPONSE_TOKENS` environment variable.

Playground mode also only counted prompt tokens, ignoring the document content — causing truncation on longer documents (#745).

## Changes

- `_calculatePromptTokenCount`: `prompt.length / 4` → `prompt.length / 2` (conservative estimate that works for all languages)
- External API data token estimation: same `/4` → `/2` fix for consistency
- All three `_calculateNumCtx` call sites: replaced hardcoded `1024`/`512` with `Number(config.responseTokens)` which reads from `RESPONSE_TOKENS` env var (defaults to 1000)
- Playground: token count now includes document content, not just the prompt

## Tested

50-doc QA setup with 10,800-char German prompt:

| | Before | After |
|---|---|---|
| Prompt token estimate | 2,700 (10,800/4) | 5,400 (10,800/2) |
| Response tokens | 1,024 (hardcoded) | from `RESPONSE_TOKENS` env var |
| num_ctx formula | 2,700 + 1,024 = 3,724 | 5,400 + RESPONSE_TOKENS, capped by TOKEN_LIMIT |

With defaults (`TOKEN_LIMIT=128000`, `RESPONSE_TOKENS=1000`): num_ctx would go from 3,724 to 6,400 — no truncation.

The `/2` estimate is conservative (overestimates), which is the safe direction — better to allocate too much context than too little.