### PR TITLE
fix: normalize API URL to prevent double /api/ paths

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -16,8 +16,10 @@ class PaperlessService {
 
   initialize() {
     if (!this.client && config.paperless.apiUrl && config.paperless.apiToken) {
+      // Normalize URL to avoid double /api/ paths when setup wizard appends /api
+      const baseURL = config.paperless.apiUrl.replace(/\/api\/?$/, '') + '/api';
       this.client = axios.create({
-        baseURL: config.paperless.apiUrl,
+        baseURL,
         headers: {
           'Authorization': `Token ${config.paperless.apiToken}`,
           'Content-Type': 'application/json'
@@ -113,8 +115,9 @@ class PaperlessService {
     }
 
   async initializeWithCredentials(apiUrl, apiToken) {
+    const baseURL = apiUrl.replace(/\/api\/?$/, '') + '/api';
     this.client = axios.create({
-      baseURL: apiUrl,
+      baseURL,
       headers: {
         'Authorization': `Token ${apiToken}`,
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary

Fixes #880

The setup wizard appends `/api` to `PAPERLESS_API_URL` when saving to `.env`. The service then uses this as the axios `baseURL`, and all endpoint paths get appended on top — resulting in `/api/api/users/` etc. Paperless-ngx returns HTML instead of JSON, causing scanning to abort.

Both `initialize()` and `initializeWithCredentials()` now normalize the URL by stripping a trailing `/api` before re-adding it. This is idempotent — URLs with or without `/api` both end up correct.

```javascript
const baseURL = apiUrl.replace(/\/api\/?$/, '') + '/api';
```

## Changes

- `services/paperlessService.js`: URL normalization in both `initialize()` and `initializeWithCredentials()`