### PR TITLE
fix: replace hardcoded max_tokens with config.responseTokens in customService

### DIFF
--- a/services/customService.js
+++ b/services/customService.js
@@ -393,7 +393,7 @@ class CustomOpenAIService {
           }
         ],
         temperature: 0.7,
-        max_tokens: 128000
+        max_tokens: Number(config.responseTokens)
       });
 
       if (!response?.choices?.[0]?.message?.content) {


### PR DESCRIPTION
## Summary

Fixes #802

`customService.js` hardcodes `max_tokens: 128000` in the API call, which breaks custom API providers with smaller context windows (they reject the request or error out).

Replaced with `Number(config.responseTokens)` which reads from the `RESPONSE_TOKENS` environment variable (default: 1000). This is the same config value already used by the Ollama service and exposed in the setup UI.

## Changes

- `services/customService.js`: `max_tokens: 128000` → `max_tokens: Number(config.responseTokens)`