### PR TITLE
feat: add BASE_PATH support for reverse proxy subpath deployments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![GitHub Stars](https://img.shields.io/github/stars/clusterzx)](https://github.com/clusterzx)
 [![License](https://img.shields.io/github/license/clusterzx/paperless-ai?cacheSeconds=1)](LICENSE)
 
+# ⚠️ IMPORTANT NOTICE:
+This repo is currently not maintained. I appreciate all the efforts from the community pushing PRs and creating issues.
+I'm currently rewriting the entire codebase with a more stable, up-to-date architecture. But I'm limited to evenings, and doing support here while also working on the rewrite just isn't feasible for me.
+With the upcoming official AI integration in Paperless-ngx itself, I'm also not sure if I'll complete the rewrite or continue maintaining this repo at all.
+
 ---
 
 **Paperless-AI** is an AI-powered extension for [Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) that brings automatic document classification, smart tagging, and semantic search using OpenAI-compatible APIs and Ollama.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ Powered by **Retrieval-Augmented Generation (RAG)**, you can now search semantic
 
 ---
 
+## 🔀 Reverse Proxy Subpath Support
+
+If you want to run paperless-ai under a subpath (e.g. `https://yourdomain.com/ai/`) behind a reverse proxy like Caddy or nginx, set the `BASE_PATH` environment variable:
+
+```yaml
+environment:
+  - BASE_PATH=/ai
+```
+
+Caddy example:
+```caddyfile
+handle_path /ai/* {
+    reverse_proxy paperless-ai:3000
+}
+```
+
+The default value is `/` which means no subpath (standard behaviour).
+
+---
+
 ## 🔧 Local Development
 
 ```bash

--- a/config/config.js
+++ b/config/config.js
@@ -4,6 +4,10 @@ const envPath = path.join(currentDir, 'data', '.env');
 console.log('Loading .env from:', envPath); // Debug log
 require('dotenv').config({ path: envPath });
 
+// Normalize BASE_PATH: '/' is the default (intuitive for end users), internally always '' or '/subpath'
+const rawBasePath = process.env.BASE_PATH || '/';
+const basePath = rawBasePath === '/' ? '' : '/' + rawBasePath.replace(/^\/|\/$/g, '');
+
 // Helper function to parse boolean-like env vars
 const parseEnvBoolean = (value, defaultValue = 'yes') => {
   if (!value) return defaultValue;
@@ -88,6 +92,7 @@ module.exports = {
     deploymentName: process.env.AZURE_DEPLOYMENT_NAME || '',
     apiVersion: process.env.AZURE_API_VERSION || '2023-05-15'
   },
+  basePath: basePath,
   customFields: process.env.CUSTOM_FIELDS || '',
   aiProvider: process.env.AI_PROVIDER || 'openai',
   scanInterval: process.env.SCAN_INTERVAL || '*/30 * * * *',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - PAPERLESS_AI_PORT=${PAPERLESS_AI_PORT:-3000}
       - RAG_SERVICE_URL=http://localhost:8000
       - RAG_SERVICE_ENABLED=true
+      # Optional: set a subpath if running behind a reverse proxy (e.g. BASE_PATH=/ai)
+      # Default is / (no subpath)
+      - BASE_PATH=${BASE_PATH:-/}
     ports:
       - "3000:${PAPERLESS_AI_PORT:-3000}"
     volumes:

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 let currentDocumentId = null;
 
 // Initialize marked with options for code highlighting
@@ -21,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function initializeChat(documentId) {
     try {
-        const response = await fetch(`/chat/init/${documentId}`);
+        const response = await fetch(`${BASE_PATH}/chat/init/${documentId}`);
         if (!response.ok) throw new Error('Failed to initialize chat');
         const data = await response.json();
         
@@ -42,7 +43,7 @@ async function initializeChat(documentId) {
 
 async function sendMessage(message) {
     try {
-        const response = await fetch('/chat/message', {
+        const response = await fetch(`${BASE_PATH}/chat/message`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 // Theme Management
 class ThemeManager {
     constructor() {
@@ -137,7 +138,7 @@ window.showTagDetails = async function() {
     window.modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/tagsCount');
+        const response = await fetch(`${BASE_PATH}/api/tagsCount`);
         const tags = await response.json();
 
         let content = '<div class="detail-list">';
@@ -165,7 +166,7 @@ window.showCorrespondentDetails = async function() {
     window.modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/correspondentsCount');
+        const response = await fetch(`${BASE_PATH}/api/correspondentsCount`);
         const correspondents = await response.json();
 
         let content = '<div class="detail-list">';
@@ -221,7 +222,7 @@ async function showTagDetails() {
     modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/tags');
+        const response = await fetch(`${BASE_PATH}/api/tags`);
         const tags = await response.json();
 
         let content = '<div class="detail-list">';
@@ -249,7 +250,7 @@ async function showCorrespondentDetails() {
     modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/correspondents');
+        const response = await fetch(`${BASE_PATH}/api/correspondents`);
         const correspondents = await response.json();
 
         let content = '<div class="detail-list">';

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 // Theme Management
 class ThemeManager {
     constructor() {
@@ -261,7 +262,7 @@ class HistoryManager {
 
     async resetDocuments(ids) {
         try {
-            const response = await fetch('/api/reset-documents', {
+            const response = await fetch(`${BASE_PATH}/api/reset-documents`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ ids })
@@ -282,7 +283,7 @@ class HistoryManager {
 
     async resetAllDocuments() {
         try {
-            const response = await fetch('/api/reset-all-documents', {
+            const response = await fetch(`${BASE_PATH}/api/reset-all-documents`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' }
             });

--- a/public/js/manual.js
+++ b/public/js/manual.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 // Theme Management
 class ThemeManager {
     constructor() {
@@ -136,7 +137,7 @@ window.showTagDetails = async function() {
     window.modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/tagsCount');
+        const response = await fetch(`${BASE_PATH}/api/tagsCount`);
         const tags = await response.json();
 
         let content = '<div class="detail-list">';
@@ -164,7 +165,7 @@ window.showCorrespondentDetails = async function() {
     window.modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/correspondentsCount');
+        const response = await fetch(`${BASE_PATH}/api/correspondentsCount`);
         const correspondents = await response.json();
 
         let content = '<div class="detail-list">';
@@ -220,7 +221,7 @@ async function showTagDetails() {
     modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/tags');
+        const response = await fetch(`${BASE_PATH}/api/tags`);
         const tags = await response.json();
 
         let content = '<div class="detail-list">';
@@ -248,7 +249,7 @@ async function showCorrespondentDetails() {
     modalManager.showLoader();
 
     try {
-        const response = await fetch('/api/correspondents');
+        const response = await fetch(`${BASE_PATH}/api/correspondents`);
         const correspondents = await response.json();
 
         let content = '<div class="detail-list">';

--- a/public/js/playground-analyzer.js
+++ b/public/js/playground-analyzer.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 // Prompt Rating System and Analyzer combined in one file
 class PromptRatingSystem {
     constructor() {
@@ -590,7 +591,7 @@ class PlaygroundAnalyzer {
 
         try {
             // Dokument-Content abrufen
-            const contentResponse = await fetch(`/manual/preview/${docId}`);
+            const contentResponse = await fetch(`${BASE_PATH}/manual/preview/${docId}`);
             if (!contentResponse.ok) throw new Error('Failed to fetch document content');
             const contentData = await contentResponse.json();
 
@@ -605,7 +606,7 @@ class PlaygroundAnalyzer {
             const existingTitle = docCard.querySelector('h3').textContent;
 
             // Analyse durchführen
-            const analysisResponse = await fetch('/manual/playground', {
+            const analysisResponse = await fetch(`${BASE_PATH}/manual/playground`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 //settings.js
 // Theme Management
 class ThemeManager {
@@ -477,7 +478,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
             if (formData.get('systemPrompt')) {
                 formData.set('systemPrompt', formData.get('systemPrompt').replace(/`/g, ''));
             }
-            const response = await fetch('/settings', {
+            const response = await fetch(`${BASE_PATH}/settings`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -1,3 +1,4 @@
+const BASE_PATH = window.BASE_PATH || "";
 class ThemeManager {
     constructor() {
         this.themeToggle = document.getElementById('themeToggle');
@@ -894,7 +895,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             try {
                 const formData = new FormData(setupForm);
-                const response = await fetch('/setup', {
+                const response = await fetch(`${BASE_PATH}/setup`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -21,6 +21,7 @@ const { authenticateJWT, isAuthenticated } = require('./auth.js');
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 const customService = require('../services/customService.js');
 const config = require('../config/config.js');
+const { basePath } = config;
 require('dotenv').config({ path: '../data/.env' });
 
 /**
@@ -158,7 +159,7 @@ router.use(async (req, res, next) => {
   } else {
     // Fallback to JWT authentication
     if (!token) {
-      return res.redirect('/login');
+      return res.redirect(`${basePath}/login`);
     }
 
     try {
@@ -166,7 +167,7 @@ router.use(async (req, res, next) => {
       req.user = decoded;
     } catch (error) {
       res.clearCookie('jwt');
-      return res.redirect('/login');
+      return res.redirect(`${basePath}/login`);
     }
   }
 
@@ -175,9 +176,9 @@ router.use(async (req, res, next) => {
     const isConfigured = await setupService.isConfigured();
  
     if (!isConfigured && (!process.env.PAPERLESS_AI_INITIAL_SETUP || process.env.PAPERLESS_AI_INITIAL_SETUP === 'no') && !req.path.startsWith('/setup')) {
-      return res.redirect('/setup');
+      return res.redirect(`${basePath}/setup`);
     } else if (!isConfigured && process.env.PAPERLESS_AI_INITIAL_SETUP === 'yes' && !req.path.startsWith('/settings')) {
-      return res.redirect('/settings');
+      return res.redirect(`${basePath}/settings`);
     }
   } catch (error) {
     console.error('Error checking setup configuration:', error);
@@ -245,9 +246,9 @@ router.get('/login', (req, res) => {
   //check if a user exists beforehand
   documentModel.getUsers().then((users) => {
     if(users.length === 0) {
-      res.redirect('setup');
+      res.redirect(`${basePath}/setup`);
     } else {
-      res.render('login', { error: null });
+      res.render('login', { error: null, basePath });
     }
   });
 });
@@ -340,7 +341,7 @@ router.post('/login', async (req, res) => {
     // Check if user was found and has required fields
     if (!user || !user.password) {
       console.log('[FAILED LOGIN] User not found or invalid data:', username);
-      return res.render('login', { error: 'Invalid credentials' });
+      return res.render('login', { error: 'Invalid credentials', basePath });
     }
 
     // Compare passwords
@@ -360,17 +361,17 @@ router.post('/login', async (req, res) => {
         httpOnly: true,
         secure: false,  
         sameSite: 'lax', 
-        path: '/',
+        path: basePath || '/',
         maxAge: 24 * 60 * 60 * 1000 
       });
 
-      return res.redirect('/dashboard');
+      return res.redirect(`${basePath}/dashboard`);
     }else{
-      return res.render('login', { error: 'Invalid credentials' });
+      return res.render('login', { error: 'Invalid credentials', basePath });
     }
   } catch (error) {
     console.error('Login error:', error);
-    res.render('login', { error: 'An error occurred during login' });
+    res.render('login', { error: 'An error occurred during login', basePath });
   }
 });
 
@@ -410,8 +411,8 @@ router.post('/login', async (req, res) => {
  *               $ref: '#/components/schemas/Error'
  */
 router.get('/logout', (req, res) => {
-  res.clearCookie('jwt');
-  res.redirect('/login');
+  res.clearCookie('jwt', { path: basePath || '/' });
+  res.redirect(`${basePath}/login`);
 });
 
 /**
@@ -554,7 +555,8 @@ router.get('/playground', protectApiRoute, async (req, res) => {
       tagNames,
       correspondentNames,
       paperlessUrl,
-      version: configFile.PAPERLESS_AI_VERSION || ' '
+      version: configFile.PAPERLESS_AI_VERSION || ' ',
+      basePath
     });
   } catch (error) {
     console.error('[ERRO] loading documents view:', error);
@@ -702,7 +704,7 @@ router.get('/chat', async (req, res) => {
       const {open} = req.query;
       const documents = await paperlessService.getDocuments();
       const version = configFile.PAPERLESS_AI_VERSION || ' ';
-      res.render('chat', { documents, open, version });
+      res.render('chat', { documents, open, version, basePath });
   } catch (error) {
     console.error('[ERRO] loading documents:', error);
     res.status(500).send('Error loading documents');
@@ -1048,7 +1050,8 @@ router.get('/history', async (req, res) => {
       filters: {
         allTags: allTags,
         allCorrespondents: allCorrespondents
-      }
+      },
+      basePath
     });
   } catch (error) {
     console.error('[ERROR] loading history page:', error);
@@ -1944,19 +1947,21 @@ router.get('/setup', async (req, res) => {
     // If everything is configured and we have users, redirect to dashboard
     // BUT only after we've loaded all the config
     if (isFullyConfigured) {
-      return res.redirect('/dashboard');
+      return res.redirect(`${basePath}/dashboard`);
     }
 
     // Render setup page with config and appropriate message
     res.render('setup', {
       config,
-      success: successMessage
+      success: successMessage,
+      basePath
     });
   } catch (error) {
     console.error('Setup route error:', error);
     res.status(500).render('setup', {
       config: {},
-      error: 'An error occurred while loading the setup page.'
+      error: 'An error occurred while loading the setup page.',
+      basePath
     });
   }
 });
@@ -2117,7 +2122,8 @@ router.get('/manual', async (req, res) => {
     version,
     paperlessUrl: process.env.PAPERLESS_API_URL,
     paperlessToken: process.env.PAPERLESS_API_TOKEN,
-    config: {}
+    config: {},
+    basePath
   });
 });
 
@@ -2608,7 +2614,8 @@ router.get('/dashboard', async (req, res) => {
       averageTotalTokens, 
       tokensOverall 
     }, 
-    version 
+    version,
+    basePath
   });
 });
 
@@ -2736,7 +2743,8 @@ router.get('/settings', async (req, res) => {
     version,
     config,
     success: isConfigured ? 'The application is already configured. You can update the configuration below.' : undefined,
-    settingsError: showErrorCheckSettings ? 'Please check your settings. Something is not working correctly.' : undefined
+    settingsError: showErrorCheckSettings ? 'Please check your settings. Something is not working correctly.' : undefined,
+    basePath
   });
 });
 
@@ -2790,7 +2798,7 @@ router.get('/debug', async (req, res) => {
   //     message: 'Application setup not completed'
   //   });
   // }
-  res.render('debug');
+  res.render('debug', { basePath });
 });
 
 // router.get('/test/:correspondent', async (req, res) => {

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ app.use((req, res, next) => {
 
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(config.basePath || '/', express.static(path.join(__dirname, 'public')));
 app.use(cookieParser());
 
 // Swagger documentation route
@@ -431,19 +431,21 @@ async function scanDocuments() {
 }
 
 // Routes
-app.use('/', setupRoutes);
+const { basePath } = config;
+app.use(basePath || '/', setupRoutes);
 const authRoutes = require('./routes/auth');
 const ragRoutes = require('./routes/rag');
 
 // Mount RAG routes if enabled
 if (process.env.RAG_SERVICE_ENABLED === 'true') {
-  app.use('/api/rag', ragRoutes);
+  app.use(`${basePath}/api/rag`, ragRoutes);
   
   // RAG UI route
-  app.get('/rag', async (req, res) => {
+  app.get(`${basePath}/rag`, async (req, res) => {
     try {
       res.render('rag', { 
-        title: 'Dokumenten-Fragen'
+        title: 'Dokumenten-Fragen',
+        basePath
       });
     } catch (error) {
       console.error('Error rendering RAG UI:', error);
@@ -477,9 +479,9 @@ if (process.env.RAG_SERVICE_ENABLED === 'true') {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-app.get('/', async (req, res) => {
+app.get(basePath || '/', async (req, res) => {
   try {
-    res.redirect('/dashboard');
+    res.redirect(`${basePath}/dashboard`);
   } catch (error) {
     console.error('[ERROR] in root route:', error);
     res.status(500).send('Error processing request');

--- a/views/chat.ejs
+++ b/views/chat.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI Chat</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -25,25 +26,25 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
-                    <li><a href="/dashboard" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a></li>
-                    <li><a href="/manual" class="sidebar-link"><i class="fas fa-file-alt"></i><span>Manual</span></a></li>
-                    <li><a href="/chat" class="sidebar-link active"><i class="fa-solid fa-comment"></i><span>Chat</span></a></li>
+                    <li><a href="<%- basePath %>/dashboard" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a></li>
+                    <li><a href="<%- basePath %>/manual" class="sidebar-link"><i class="fas fa-file-alt"></i><span>Manual</span></a></li>
+                    <li><a href="<%- basePath %>/chat" class="sidebar-link active"><i class="fa-solid fa-comment"></i><span>Chat</span></a></li>
                     <li>
-                        <a href="/rag" class="sidebar-link">
+                        <a href="<%- basePath %>/rag" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>RAG Chat</span>
                         </a>
                     </li>
-                    <li><a href="/playground" class="sidebar-link"><i class="fa-solid fa-flask-vial"></i><span>Playground</span></a></li>
-                    <li><a href="/history" class="sidebar-link"><i class="fa-solid fa-clock-rotate-left"></i><span>History</span></a></li>
-                    <li><a href="/settings" class="sidebar-link"><i class="fas fa-cog"></i><span>Settings</span></a></li>
-                    <li><a href="/logout" class="sidebar-link"><i class="fa-solid fa-right-from-bracket"></i><span>Logout</span></a></li>
+                    <li><a href="<%- basePath %>/playground" class="sidebar-link"><i class="fa-solid fa-flask-vial"></i><span>Playground</span></a></li>
+                    <li><a href="<%- basePath %>/history" class="sidebar-link"><i class="fa-solid fa-clock-rotate-left"></i><span>History</span></a></li>
+                    <li><a href="<%- basePath %>/settings" class="sidebar-link"><i class="fas fa-cog"></i><span>Settings</span></a></li>
+                    <li><a href="<%- basePath %>/logout" class="sidebar-link"><i class="fa-solid fa-right-from-bracket"></i><span>Logout</span></a></li>
                 </ul>
                 <a href="https://github.com/clusterzx/paperless-ai" 
                 class="github-button" 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI Dashboard</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -22,56 +23,56 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                    <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                    <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
                     <li>
-                        <a href="/dashboard" class="sidebar-link active">
+                        <a href="<%- basePath %>/dashboard" class="sidebar-link active">
                             <i class="fas fa-home"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/manual" class="sidebar-link">
+                        <a href="<%- basePath %>/manual" class="sidebar-link">
                             <i class="fas fa-file-alt"></i>
                             <span>Manual</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/chat" class="sidebar-link">
+                        <a href="<%- basePath %>/chat" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>Chat</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/rag" class="sidebar-link">
+                        <a href="<%- basePath %>/rag" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>RAG Chat</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/playground" class="sidebar-link">
+                        <a href="<%- basePath %>/playground" class="sidebar-link">
                             <i class="fa-solid fa-flask-vial"></i>
                             <span>Playground</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/history" class="sidebar-link">
+                        <a href="<%- basePath %>/history" class="sidebar-link">
                             <i class="fa-solid fa-clock-rotate-left"></i>
                             <span>History</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/settings" class="sidebar-link">
+                        <a href="<%- basePath %>/settings" class="sidebar-link">
                             <i class="fas fa-cog"></i>
                             <span>Settings</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/logout" class="sidebar-link">
+                        <a href="<%- basePath %>/logout" class="sidebar-link">
                             <i class="fa-solid fa-right-from-bracket"></i>
                             <span>Logout</span>
                         </a>

--- a/views/debug.ejs
+++ b/views/debug.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Debug Interface</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/alpinejs/3.13.5/cdn.min.js" defer></script>

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -3,6 +3,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Modified Documents - Paperless-AI</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -52,20 +53,20 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
-                    <li><a href="/dashboard" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a></li>
-                    <li><a href="/manual" class="sidebar-link"><i class="fas fa-file-alt"></i><span>Manual</span></a></li>
-                    <li><a href="/chat" class="sidebar-link"><i class="fa-solid fa-comment"></i><span>Chat</span></a></li>
-                    <li><a href="/rag" class="sidebar-link"><i class="fa-solid fa-comment"></i><span>RAG Chat</span></a></li>
-                    <li><a href="/playground" class="sidebar-link"><i class="fa-solid fa-flask-vial"></i><span>Playground</span></a></li>
-                    <li><a href="/history" class="sidebar-link active"><i class="fa-solid fa-clock-rotate-left"></i><span>History</span></a></li>
-                    <li><a href="/settings" class="sidebar-link"><i class="fas fa-cog"></i><span>Settings</span></a></li>
-                    <li><a href="/logout" class="sidebar-link"><i class="fa-solid fa-right-from-bracket"></i><span>Logout</span></a></li>
+                    <li><a href="<%- basePath %>/dashboard" class="sidebar-link"><i class="fas fa-home"></i><span>Dashboard</span></a></li>
+                    <li><a href="<%- basePath %>/manual" class="sidebar-link"><i class="fas fa-file-alt"></i><span>Manual</span></a></li>
+                    <li><a href="<%- basePath %>/chat" class="sidebar-link"><i class="fa-solid fa-comment"></i><span>Chat</span></a></li>
+                    <li><a href="<%- basePath %>/rag" class="sidebar-link"><i class="fa-solid fa-comment"></i><span>RAG Chat</span></a></li>
+                    <li><a href="<%- basePath %>/playground" class="sidebar-link"><i class="fa-solid fa-flask-vial"></i><span>Playground</span></a></li>
+                    <li><a href="<%- basePath %>/history" class="sidebar-link active"><i class="fa-solid fa-clock-rotate-left"></i><span>History</span></a></li>
+                    <li><a href="<%- basePath %>/settings" class="sidebar-link"><i class="fas fa-cog"></i><span>Settings</span></a></li>
+                    <li><a href="<%- basePath %>/logout" class="sidebar-link"><i class="fa-solid fa-right-from-bracket"></i><span>Logout</span></a></li>
                 </ul>
                 <a href="https://github.com/clusterzx/paperless-ai" 
                 class="github-button" 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - Paperless-AI</title>
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/dashboard.css">
@@ -17,13 +18,13 @@
         <div class="material-card w-full max-w-md">
             <div class="text-center mb-8">
                 <div class="flex flex-col items-center justify-center gap-4 mb-6">
-                    <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                    <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                     <h1 class="brand-title text-2xl">Paperless-AI</h1>
                 </div>
                 <h2 class="text-xl font-bold">Sign in to your account</h2>
             </div>
 
-            <form class="space-y-6" action="/login" method="POST">
+            <form class="space-y-6" action="<%- basePath %>/login" method="POST">
                 <div>
                     <label for="username" class="block text-sm font-medium mb-2">Username</label>
                     <input id="username" 

--- a/views/manual.ejs
+++ b/views/manual.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI Dashboard</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -22,56 +23,56 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
                     <li>
-                        <a href="/dashboard" class="sidebar-link">
+                        <a href="<%- basePath %>/dashboard" class="sidebar-link">
                             <i class="fas fa-home"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/manual" class="sidebar-link active">
+                        <a href="<%- basePath %>/manual" class="sidebar-link active">
                             <i class="fas fa-file-alt"></i>
                             <span>Manual</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/chat" class="sidebar-link">
+                        <a href="<%- basePath %>/chat" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>Chat</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/rag" class="sidebar-link">
+                        <a href="<%- basePath %>/rag" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>RAG Chat</span>
                         </a>
                     </li>                    
                     <li>
-                        <a href="/playground" class="sidebar-link">
+                        <a href="<%- basePath %>/playground" class="sidebar-link">
                             <i class="fa-solid fa-flask-vial"></i>
                             <span>Playground</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/history" class="sidebar-link">
+                        <a href="<%- basePath %>/history" class="sidebar-link">
                             <i class="fa-solid fa-clock-rotate-left"></i>
                             <span>History</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/settings" class="sidebar-link">
+                        <a href="<%- basePath %>/settings" class="sidebar-link">
                             <i class="fas fa-cog"></i>
                             <span>Settings</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/logout" class="sidebar-link">
+                        <a href="<%- basePath %>/logout" class="sidebar-link">
                             <i class="fa-solid fa-right-from-bracket"></i>
                             <span>Logout</span>
                         </a>

--- a/views/playground.ejs
+++ b/views/playground.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI Documents</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -46,56 +47,56 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                <img src="/favicon.ico" alt="Paperless AI Logo" style="height: 60px;">
+                <img src="<%- basePath %>/favicon.ico" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
                     <li>
-                        <a href="/dashboard" class="sidebar-link">
+                        <a href="<%- basePath %>/dashboard" class="sidebar-link">
                             <i class="fas fa-home"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/manual" class="sidebar-link">
+                        <a href="<%- basePath %>/manual" class="sidebar-link">
                             <i class="fas fa-file-alt"></i>
                             <span>Manual</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/chat" class="sidebar-link">
+                        <a href="<%- basePath %>/chat" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>Chat</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/rag" class="sidebar-link">
+                        <a href="<%- basePath %>/rag" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>RAG Chat</span>
                         </a>
                     </li>                     
                     <li>
-                        <a href="/playground" class="sidebar-link active">
+                        <a href="<%- basePath %>/playground" class="sidebar-link active">
                             <i class="fa-solid fa-flask-vial"></i>
                             <span>Playground</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/history" class="sidebar-link">
+                        <a href="<%- basePath %>/history" class="sidebar-link">
                             <i class="fa-solid fa-clock-rotate-left"></i>
                             <span>History</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/settings" class="sidebar-link">
+                        <a href="<%- basePath %>/settings" class="sidebar-link">
                             <i class="fas fa-cog"></i>
                             <span>Settings</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/logout" class="sidebar-link">
+                        <a href="<%- basePath %>/logout" class="sidebar-link">
                             <i class="fa-solid fa-right-from-bracket"></i>
                             <span>Logout</span>
                         </a>
@@ -149,7 +150,7 @@
                         <div class="material-card document-card" data-document-id="<%= doc.id %>">
                             <!-- Thumbnail -->
                             <div class="relative aspect-[3/4]">
-                                <img src="/thumb/<%= doc.id %>" 
+                                <img src="<%- basePath %>/thumb/<%= doc.id %>" 
                                      alt="<%= doc.title %>"
                                      class="w-full h-full object-cover rounded-lg">
                                 

--- a/views/rag.ejs
+++ b/views/rag.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI RAG</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -619,7 +620,7 @@
 <body>
 <header>
         <div class="back-button">
-            <a href="/dashboard" title="Back to Dashboard">
+            <a href="<%- basePath %>/dashboard" title="Back to Dashboard">
                 <i class="fas fa-arrow-left"></i>
             </a>
         </div>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-AI Dashboard</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -87,56 +88,56 @@
         <div id="sidebarOverlay" class="sidebar-overlay"></div>
         <aside class="sidebar">
             <div class="sidebar-header">
-                <img src="/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
+                <img src="<%- basePath %>/favicon.ico" class="no-invert" alt="Paperless AI Logo" style="height: 60px;">
                 <h1 class="brand-title">Paperless-AI<small style="display: block;"><%= version %></small></h1>
             </div>
 
             <nav class="sidebar-nav">
                 <ul>
                     <li>
-                        <a href="/dashboard" class="sidebar-link">
+                        <a href="<%- basePath %>/dashboard" class="sidebar-link">
                             <i class="fas fa-home"></i>
                             <span>Dashboard</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/manual" class="sidebar-link">
+                        <a href="<%- basePath %>/manual" class="sidebar-link">
                             <i class="fas fa-file-alt"></i>
                             <span>Manual</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/chat" class="sidebar-link">
+                        <a href="<%- basePath %>/chat" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>Chat</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/rag" class="sidebar-link">
+                        <a href="<%- basePath %>/rag" class="sidebar-link">
                             <i class="fa-solid fa-comment"></i>
                             <span>RAG Chat</span>
                         </a>
                     </li>                     
                     <li>
-                        <a href="/playground" class="sidebar-link">
+                        <a href="<%- basePath %>/playground" class="sidebar-link">
                             <i class="fa-solid fa-flask-vial"></i>
                             <span>Playground</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/history" class="sidebar-link">
+                        <a href="<%- basePath %>/history" class="sidebar-link">
                             <i class="fa-solid fa-clock-rotate-left"></i>
                             <span>History</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/settings" class="sidebar-link active">
+                        <a href="<%- basePath %>/settings" class="sidebar-link active">
                             <i class="fas fa-cog"></i>
                             <span>Settings</span>
                         </a>
                     </li>
                     <li>
-                        <a href="/logout" class="sidebar-link">
+                        <a href="<%- basePath %>/logout" class="sidebar-link">
                             <i class="fa-solid fa-right-from-bracket"></i>
                             <span>Logout</span>
                         </a>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -2,6 +2,7 @@
 <html lang="en" class="h-full" data-theme="light">
 <head>
     <meta charset="UTF-8">
+    <script>window.BASE_PATH = '<%- basePath %>';</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperless-ai Setup</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
@@ -25,7 +26,7 @@
             <div class="mx-auto max-w-7xl px-6 lg:px-8">
                 <div class="flex h-24 items-center justify-between">
                     <div class="flex items-center space-x-6">
-                        <img src="/favicon.ico" alt="Paperless AI Logo" style="height: 60px;">
+                        <img src="<%- basePath %>/favicon.ico" alt="Paperless AI Logo" style="height: 60px;">
                         <div>
                             <h1 class="text-2xl font-bold">Paperless-AI <small><%= config.PAPERLESS_AI_VERSION %></small></h1>
                             <p class="text-sm text-secondary">Configuration Setup</p>


### PR DESCRIPTION
# Problem
paperless-ai uses hardcoded absolute paths (`/login`, `/dashboard`, etc.) throughout, making it impossible to deploy under a subpath via a reverse proxy.

# Solution
Add `BASE_PATH` environment variable support. Default is `/` (no-op, fully backward compatible). Set `BASE_PATH=/ai` to serve the app under `/ai/`.

# Example Usage

**Caddyfile:**
```caddyfile
handle_path /ai/* {
    reverse_proxy paperless-ai:3000
}
```

**docker-compose:**
```yaml
environment:
  - BASE_PATH=/ai
```