### PR TITLE
feat(tags): make tag cache lifetime and page size configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 CUSTOM_API_KEY=xxxxxxxxxxxxxxxxxxxxxxx
 CUSTOM_BASE_URL=https://api.deepseek.com/v1
 CUSTOM_MODEL=deepseek-chat
+# How long the tag cache stays valid, in milliseconds (default: 3000).
+# Raise this on installations with many tags so /api/tags/ is polled less often.
+TAG_CACHE_LIFETIME=3000
+# How many tags are requested per /api/tags/ page when the cache is refreshed
+# (default: 100). Raising this reduces the number of requests per refresh.
+TAG_PAGE_SIZE=100

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ Powered by **Retrieval-Augmented Generation (RAG)**, you can now search semantic
 
 ---
 
+## ⚡ Tag Cache Tuning
+
+Paperless-AI keeps a local cache of the tags in Paperless-ngx. On installations
+with a large tag vocabulary, `/api/tags/` gets slow, and the defaults can make it
+the dominant cost of processing a document. Two optional environment variables
+control this:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `TAG_CACHE_LIFETIME` | `3000` | How long the tag cache stays valid, in milliseconds. The default of 3 seconds means the cache typically expires while a single document is still being analyzed, so it is rebuilt for nearly every document. |
+| `TAG_PAGE_SIZE` | `100` | How many tags are requested per `/api/tags/` page when the cache is refreshed. Raising it means fewer sequential requests per refresh. |
+
+Invalid or non-positive values fall back to the defaults.
+
+For example, with several thousand tags, `TAG_CACHE_LIFETIME=3600000` (1 hour)
+and `TAG_PAGE_SIZE=1000` reduce tag fetching from tens of requests per document
+to a handful per hour.
+
+---
+
 ## 🔧 Local Development
 
 ```bash
@@ -89,6 +109,9 @@ npm install
 
 # Start development/test mode
 npm run test
+
+# Run the unit tests
+npm run test:unit
 ```
 
 ---

--- a/config/config.js
+++ b/config/config.js
@@ -10,6 +10,21 @@ const parseEnvBoolean = (value, defaultValue = 'yes') => {
   return value.toLowerCase() === 'true' || value === '1' || value.toLowerCase() === 'yes' ? 'yes' : 'no';
 };
 
+// Helper function to parse positive-integer env vars, falling back to a default
+// when the value is missing, not a number, or not strictly positive.
+const parseEnvPositiveInt = (value, defaultValue) => {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+};
+
+// Tag cache tuning. Both defaults keep the previous behaviour for the common
+// case; installations with a large number of tags can raise them so that
+// /api/tags/ is polled far less often. See TAG_CACHE_LIFETIME / TAG_PAGE_SIZE.
+const tagCacheConfig = {
+  lifetime: parseEnvPositiveInt(process.env.TAG_CACHE_LIFETIME, 3000),
+  pageSize: parseEnvPositiveInt(process.env.TAG_PAGE_SIZE, 100)
+};
+
 // Initialize limit functions with defaults
 const limitFunctions = {
   activateTagging: parseEnvBoolean(process.env.ACTIVATE_TAGGING, 'yes'),
@@ -48,7 +63,8 @@ console.log('Loaded environment variables:', {
   PAPERLESS_API_TOKEN: '******',
   LIMIT_FUNCTIONS: limitFunctions,
   AI_RESTRICTIONS: aiRestrictions,
-  EXTERNAL_API: externalApiConfig.enabled === 'yes' ? 'enabled' : 'disabled'
+  EXTERNAL_API: externalApiConfig.enabled === 'yes' ? 'enabled' : 'disabled',
+  TAG_CACHE: tagCacheConfig
 });
 
 module.exports = {
@@ -70,6 +86,9 @@ module.exports = {
     apiUrl: process.env.PAPERLESS_API_URL,
     apiToken: process.env.PAPERLESS_API_TOKEN
   },
+  // Tag cache tuning (see parseEnvPositiveInt above)
+  tagCacheLifetime: tagCacheConfig.lifetime,
+  tagPageSize: tagCacheConfig.pageSize,
   openai: {
     apiKey: process.env.OPENAI_API_KEY
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "AI based Tag, correspondent and meta data generation",
   "main": "server.js",
   "scripts": {
-    "test": "nodemon server.js"
+    "test": "nodemon server.js",
+    "test:unit": "node --test \"test/**/*.test.js\""
   },
   "keywords": [
     "paperless-ngx",

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -4078,7 +4078,9 @@ router.post('/settings', express.json(), async (req, res) => {
       EXTERNAL_API_HEADERS: process.env.EXTERNAL_API_HEADERS || '{}',
       EXTERNAL_API_BODY: process.env.EXTERNAL_API_BODY || '{}',
       EXTERNAL_API_TIMEOUT: process.env.EXTERNAL_API_TIMEOUT || '5000',
-      EXTERNAL_API_TRANSFORM: process.env.EXTERNAL_API_TRANSFORM || ''
+      EXTERNAL_API_TRANSFORM: process.env.EXTERNAL_API_TRANSFORM || '',
+      TAG_CACHE_LIFETIME: process.env.TAG_CACHE_LIFETIME || '3000',
+      TAG_PAGE_SIZE: process.env.TAG_PAGE_SIZE || '100'
     };
 
     // Process custom fields

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -11,7 +11,9 @@ class PaperlessService {
     this.tagCache = new Map();
     this.customFieldCache = new Map();
     this.lastTagRefresh = 0;
-    this.CACHE_LIFETIME = 3000; // 3 Sekunden
+    // Configurable through TAG_CACHE_LIFETIME (ms) and TAG_PAGE_SIZE, see config/config.js
+    this.CACHE_LIFETIME = config.tagCacheLifetime;
+    this.TAG_PAGE_SIZE = config.tagPageSize;
   }
 
   initialize() {
@@ -63,7 +65,7 @@ class PaperlessService {
       try {
         console.log('[DEBUG] Refreshing tag cache...');
         this.tagCache.clear();
-        let nextUrl = '/tags/';
+        let nextUrl = `/tags/?page_size=${this.TAG_PAGE_SIZE}`;
         while (nextUrl) {
           const response = await this.client.get(nextUrl);
 

--- a/test/tagCache.test.js
+++ b/test/tagCache.test.js
@@ -1,0 +1,142 @@
+// test/tagCache.test.js
+// Unit tests for the configurable tag cache (TAG_CACHE_LIFETIME / TAG_PAGE_SIZE).
+// Run with: npm run test:unit
+const test = require('node:test');
+const assert = require('node:assert');
+
+const CONFIG_PATH = require.resolve('../config/config');
+const SERVICE_PATH = require.resolve('../services/paperlessService');
+
+const TUNABLES = ['TAG_CACHE_LIFETIME', 'TAG_PAGE_SIZE'];
+
+/**
+ * Loads a fresh paperlessService singleton with the given tag cache env vars.
+ * Both values are read once, when the service is constructed, so the module
+ * cache has to be dropped between cases.
+ * @param {object} env Values for TAG_CACHE_LIFETIME / TAG_PAGE_SIZE, or undefined to unset
+ * @returns {object} A freshly constructed paperlessService
+ */
+function loadService(env = {}) {
+  const saved = {};
+  for (const key of TUNABLES) {
+    saved[key] = process.env[key];
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = String(env[key]);
+    }
+  }
+
+  delete require.cache[CONFIG_PATH];
+  delete require.cache[SERVICE_PATH];
+  const service = require(SERVICE_PATH);
+
+  for (const key of TUNABLES) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+  return service;
+}
+
+/**
+ * Minimal stand-in for the axios client, recording every requested URL.
+ * @param {Array<object>} pages Response bodies to hand back, in order
+ * @returns {object} A fake client exposing get() and the requested URLs
+ */
+function fakeClient(pages) {
+  const requested = [];
+  return {
+    requested,
+    defaults: { baseURL: 'http://paperless.local/api' },
+    get: async (url) => {
+      requested.push(url);
+      const page = pages[requested.length - 1];
+      if (!page) {
+        throw new Error(`Unexpected request #${requested.length} to ${url}`);
+      }
+      return { data: page };
+    }
+  };
+}
+
+const onePage = [{ results: [{ id: 1, name: 'Invoice' }], next: null }];
+
+test('refreshTagCache defaults to a page size of 100', async () => {
+  const service = loadService();
+  const client = fakeClient(onePage);
+  service.client = client;
+
+  await service.refreshTagCache();
+
+  assert.deepStrictEqual(client.requested, ['/tags/?page_size=100']);
+  assert.strictEqual(service.tagCache.get('invoice').id, 1);
+});
+
+test('refreshTagCache honours TAG_PAGE_SIZE', async () => {
+  const service = loadService({ TAG_PAGE_SIZE: 1000 });
+  const client = fakeClient(onePage);
+  service.client = client;
+
+  await service.refreshTagCache();
+
+  assert.strictEqual(service.TAG_PAGE_SIZE, 1000);
+  assert.deepStrictEqual(client.requested, ['/tags/?page_size=1000']);
+});
+
+test('refreshTagCache keeps the page size across paginated responses', async () => {
+  const service = loadService({ TAG_PAGE_SIZE: 2 });
+  const client = fakeClient([
+    {
+      results: [{ id: 1, name: 'Invoice' }, { id: 2, name: 'Receipt' }],
+      next: 'http://paperless.local/api/tags/?page=2&page_size=2'
+    },
+    { results: [{ id: 3, name: 'Contract' }], next: null }
+  ]);
+  service.client = client;
+
+  await service.refreshTagCache();
+
+  assert.deepStrictEqual(client.requested, [
+    '/tags/?page_size=2',
+    '/tags/?page=2&page_size=2'
+  ]);
+  assert.strictEqual(service.tagCache.size, 3);
+});
+
+test('invalid TAG_PAGE_SIZE and TAG_CACHE_LIFETIME fall back to the defaults', () => {
+  for (const value of ['not-a-number', '0', '-5', '']) {
+    const service = loadService({ TAG_PAGE_SIZE: value, TAG_CACHE_LIFETIME: value });
+    assert.strictEqual(service.TAG_PAGE_SIZE, 100, `TAG_PAGE_SIZE=${value}`);
+    assert.strictEqual(service.CACHE_LIFETIME, 3000, `TAG_CACHE_LIFETIME=${value}`);
+  }
+});
+
+test('ensureTagCache does not refetch while the cache is still fresh', async () => {
+  const service = loadService({ TAG_CACHE_LIFETIME: 3600000 });
+  const client = fakeClient(onePage);
+  service.client = client;
+
+  assert.strictEqual(service.CACHE_LIFETIME, 3600000);
+
+  await service.ensureTagCache();
+  await service.ensureTagCache();
+  await service.ensureTagCache();
+
+  assert.strictEqual(client.requested.length, 1, 'expected a single refresh');
+});
+
+test('ensureTagCache refetches once TAG_CACHE_LIFETIME has elapsed', async () => {
+  const service = loadService({ TAG_CACHE_LIFETIME: 3600000 });
+  const client = fakeClient([...onePage, ...onePage]);
+  service.client = client;
+
+  await service.ensureTagCache();
+  // Pretend the last refresh happened just over an hour ago.
+  service.lastTagRefresh = Date.now() - 3600001;
+  await service.ensureTagCache();
+
+  assert.strictEqual(client.requested.length, 2);
+});


### PR DESCRIPTION
## Problem

`refreshTagCache()` walks `/api/tags/` with a hardcoded 3 second cache lifetime and **no `page_size`**. On installations with a large tag vocabulary this becomes the dominant cost of processing a document — far bigger than the LLM call.

Two things compound:

1. `this.CACHE_LIFETIME = 3000` (3 *seconds*), so the cache typically expires before a single document finishes being analyzed, and `refreshTagCache()` reruns for essentially every document.
2. `refreshTagCache()` sends no `page_size`, so it falls back to the API default of 25 objects per page — one refresh becomes many sequential requests.

That would be tolerable if `/api/tags/` were cheap, but it isn't. paperless-ngx's `TagViewSet.list()` materialises *every* tag and walks `get_descendants_pks()` on each one **before** it paginates (hierarchical tag support), so the endpoint costs O(total tags) regardless of the requested page size. Measured on a 3790-tag install running paperless-ngx 3.0.5:

| Request | Time |
| --- | --- |
| `/api/tags/?page_size=1` | 6.6s |
| `/api/tags/?page_size=1000` | 8.7s |
| `/api/correspondents/` (1540 objects, no such override) | 0.08s |

So one cache refresh was ~38 sequential multi-second requests, once per document — roughly 4 minutes per document, all of it spent re-reading tags.

Note that `getTags()` already hardcodes `page_size: 100`, as do the other list helpers in this service (`/documents/`, `/correspondents/`, …). `refreshTagCache()` is the one list walk that doesn't.

## Change

Two optional environment variables, read in `config/config.js` alongside the existing helpers:

| Variable | Default | Description |
| --- | --- | --- |
| `TAG_CACHE_LIFETIME` | `3000` | Tag cache lifetime in milliseconds — unchanged from today's hardcoded value. |
| `TAG_PAGE_SIZE` | `100` | Tags requested per `/api/tags/` page, matching the `page_size: 100` already used elsewhere in this service. |

Invalid, non-numeric or non-positive values fall back to the defaults via a new `parseEnvPositiveInt` helper, mirroring the existing `parseEnvBoolean`.

`TAG_CACHE_LIFETIME` keeps its current default, so behaviour is unchanged unless you opt in. `TAG_PAGE_SIZE` defaults to `100` rather than the API's implicit `25` — this is the one behavioural change, and it only ever means strictly fewer requests for the same data, consistent with every other paginated call in the file. Happy to default it to `25` instead if you'd prefer literally zero behaviour change.

The two keys are also added to the `currentConfig` object in `routes/setup.js`, so they round-trip through `data/.env` on a settings save instead of being silently dropped (same pattern as the other env-only keys there).

On the install above, `TAG_CACHE_LIFETIME=3600000` + `TAG_PAGE_SIZE=1000` took processing from >1 min/document to ~15s/document — 4 tag requests per hour instead of ~38 per document.

## Tests

There was no test setup in the repo, so this adds `test/tagCache.test.js` using the **built-in Node test runner** — no new dependencies, and `npm test` is left exactly as it was. New script:

```bash
npm run test:unit
```

Covers: the default page size, `TAG_PAGE_SIZE` being honoured, the page size surviving across paginated `next` URLs, invalid values falling back to defaults, and `ensureTagCache()` respecting `TAG_CACHE_LIFETIME` in both directions.

```
# tests 6
# pass 6
# fail 0
```

Verified on `node:22-slim` (matching the `Dockerfile`). I also confirmed the tests actually catch a regression: reverting the `page_size` line alone turns 3 of the 6 red. `npx eslint` on the changed files reports no new problems (the 4 errors in `services/paperlessService.js` are pre-existing and on untouched lines).

## Note

I saw the maintenance notice in the README — no expectation of a quick review. Opening this anyway since it's small, opt-in, and it's a workaround I'd otherwise have to keep carrying downstream as a `sed` patch against the image. Feel free to close if it doesn't fit the rewrite.