### PR TITLE
feat(ollama): add OLLAMA_THINK toggle to support reasoning models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ OPENAI_API_KEY=
 OPENAI_MODEL=
 OLLAMA_API_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2
+# Ollama native thinking toggle. Leave blank to use the model default.
+# Set to false to disable reasoning output (needed for reasoning models such
+# as Qwen3 / Deepseek-r1, which otherwise return empty responses on /api/generate).
+OLLAMA_THINK=
 SCAN_INTERVAL=*/30 * * * *
 SYSTEM_PROMPT=`You are a personalized document analyzer. Your task is to analyze documents and extract relevant information.\n\nAnalyze the document content and extract the following information into a structured JSON object:\n\n1. title: Create a concise, meaningful title for the document\n2. correspondent: Identify the sender/institution but do not include addresses\n3. tags: Select up to 4 relevant thematic tags\n4. document_date: Extract the document date (format: YYYY-MM-DD)\n5. language: Determine the document language (e.g. "de" or "en")\n      \nImportant rules for the analysis:\n\nFor tags:\n- FIRST check the existing tags before suggesting new ones\n- Use only relevant categories\n- Maximum 4 tags per document, less if sufficient (at least 1)\n- Avoid generic or too specific tags\n- Use only the most important information for tag creation\n- The output language is the one used in the document! IMPORTANT!\n\nFor the title:\n- Short and concise, NO ADDRESSES\n- Contains the most important identification features\n- For invoices/orders, mention invoice/order number if available\n- The output language is the one used in the document! IMPORTANT!\n\nFor the correspondent:\n- Identify the sender or institution\n  When generating the correspondent, always create the shortest possible form of the company name (e.g. "Amazon" instead of "Amazon EU SARL, German branch")\n\nFor the document date:\n- Extract the date of the document\n- Use the format YYYY-MM-DD\n- If multiple dates are present, use the most relevant one\n\nFor the language:\n- Determine the document language\n- Use language codes like "de" for German or "en" for English\n- If the language is not clear, use "und" as a placeholder
 `

--- a/config/config.js
+++ b/config/config.js
@@ -10,6 +10,15 @@ const parseEnvBoolean = (value, defaultValue = 'yes') => {
   return value.toLowerCase() === 'true' || value === '1' || value.toLowerCase() === 'yes' ? 'yes' : 'no';
 };
 
+// Helper to parse tri-state boolean env vars: returns true/false, or undefined when unset
+const parseOptionalBoolean = (value) => {
+  if (value === undefined || value === null || value === '') return undefined;
+  const v = String(value).toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(v)) return true;
+  if (['false', '0', 'no', 'off'].includes(v)) return false;
+  return undefined;
+};
+
 // Initialize limit functions with defaults
 const limitFunctions = {
   activateTagging: parseEnvBoolean(process.env.ACTIVATE_TAGGING, 'yes'),
@@ -75,7 +84,11 @@ module.exports = {
   },
   ollama: {
     apiUrl: process.env.OLLAMA_API_URL || 'http://localhost:11434',
-    model: process.env.OLLAMA_MODEL || 'llama3.2'
+    model: process.env.OLLAMA_MODEL || 'llama3.2',
+    // Ollama native thinking toggle. Unset = use the model default; false disables
+    // reasoning output, required for reasoning models (Qwen3, Deepseek-r1, ...) which
+    // otherwise spend the num_predict budget on <think> and return no answer.
+    think: parseOptionalBoolean(process.env.OLLAMA_THINK)
   },
   custom: {
     apiUrl: process.env.CUSTOM_BASE_URL || '',

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -23,6 +23,7 @@ class OllamaService {
     constructor() {
         this.apiUrl = config.ollama.apiUrl;
         this.model = config.ollama.model;
+        this.think = config.ollama.think;
         this.client = axios.create({
             timeout: 1800000 // 30 minutes timeout
         });
@@ -545,6 +546,7 @@ class OllamaService {
             prompt: prompt,
             system: systemPrompt,
             stream: false,
+            ...(this.think !== undefined && { think: this.think }),
             format: schema,
             options: {
                 temperature: 0.7,
@@ -696,6 +698,7 @@ class OllamaService {
                 prompt: prompt,
                 system: systemPrompt,
                 stream: false,
+                ...(this.think !== undefined && { think: this.think }),
                 options: {
                     temperature: 0.7,
                     top_p: 0.9,


### PR DESCRIPTION
## Problem
The README lists Deepseek-r1 (a reasoning model) as supported, but reasoning models fail to analyze any document with Ollama. `services/ollamaService.js` calls `/api/generate` with `num_predict: 256` and a JSON-schema `format` constraint. Reasoning models (Qwen3, Deepseek-r1, gpt-oss) emit their `<think>` output first and use up the token budget before they reach the schema-constrained answer, so every document fails with `No response data from Ollama API`. The `/no_think` prompt directive does not reliably stop this; Ollama's native `think` request field does.

## Change
Add an optional `OLLAMA_THINK` env var wired to Ollama's `think` field on both `/api/generate` calls. Unset (the default) omits `think` and keeps current behavior, `false` disables reasoning output, and `true` forces it. Installs that do not set the variable are unaffected.

## Files
- `config/config.js`: `parseOptionalBoolean` helper and `ollama.think`
- `services/ollamaService.js`: pass `think` on both `/api/generate` requests
- `.env.example`: document `OLLAMA_THINK`

## Testing
I deployed the patched build against a local reasoning model with `OLLAMA_THINK=false`. Documents that previously failed with "No response data" now analyze and tag correctly, with no errors across a full scan. With the variable unset, behavior is unchanged.
